### PR TITLE
add a type for reachability

### DIFF
--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -631,6 +631,7 @@ fn default_peer() -> Peer {
         time: Default::default(),
         peer_id: ReferenceId::from_int(0),
         our_id: ReferenceId::from_int(0),
+        reach: Reach::default(),
     }
 }
 
@@ -791,8 +792,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
 
         assert!(
@@ -809,8 +809,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         assert!(
             reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
@@ -826,8 +825,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         assert!(
             reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
@@ -843,8 +841,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(0),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         assert!(
             reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
@@ -861,8 +858,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         packet.root_delay = NtpDuration::from_fixed_int(100000000);
         assert!(
@@ -880,8 +876,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         packet.root_dispersion = NtpDuration::from_fixed_int(100000000);
         assert!(
@@ -898,8 +893,7 @@ mod test {
             last_measurements: Default::default(),
             last_packet: packet.clone(),
             time: NtpTimestamp::from_fixed_int(100000000),
-            peer_id: ReferenceId::from_int(0),
-            our_id: ReferenceId::from_int(0),
+            ..default_peer()
         };
         assert_eq!(
             reference.root_distance(NtpTimestamp::from_fixed_int(100000000)),

--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -336,7 +336,10 @@ impl Peer {
             return false;
         }
 
-        // TODO: An unreachable error occurs if the server is unreachable.
+        // An unreachable error occurs if the server is unreachable.
+        if !self.reach.is_reachable() {
+            return false;
+        }
 
         true
     }


### PR DESCRIPTION
effectively a cherry-pick from #36 

The `Reach` type is currently unused in the code, but it is tested.

The naming is taken from the spec, but I'm not totally happy with it. But `reachability` in full also doesn't really work (`peer.reachability.received_packet()` just doesn't look right to me). So, suggestions welcome I guess, but `reach` at least mirrors the spec and it's not terrible