### PR TITLE
reorganize filter.rs into more files

### DIFF
--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -331,7 +331,7 @@ pub fn fuzz_find_interval(spec: &[(i64, u64)]) {
     let survivors = construct_survivors(&candidates, NtpTimestamp::from_fixed_int(0));
 
     // check that if we find a cluster, it contains more than half of the peers we work with.
-    assert!(survivors.len() == 0 || 2 * survivors.len() > spec.len());
+    assert!(survivors.is_empty() || 2 * survivors.len() > spec.len());
 }
 
 #[cfg(test)]

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -1,0 +1,731 @@
+use crate::peer::{Peer, MAX_DISTANCE};
+use crate::{NtpDuration, NtpTimestamp};
+
+// TODO this should be 4 in production?!
+/// Minimum number of survivors needed to be able to discipline the system clock.
+/// More survivors (so more servers from which to get the time) means a more accurate time.
+///
+/// The spec notes (CMIN was renamed to MIN_INTERSECTION_SURVIVORS in our implementation):
+///
+/// > CMIN defines the minimum number of servers consistent with the correctness requirements.
+/// > Suspicious operators would set CMIN to ensure multiple redundant servers are available for the
+/// > algorithms to mitigate properly. However, for historic reasons the default value for CMIN is one.
+const MIN_INTERSECTION_SURVIVORS: usize = 1;
+
+/// Number of survivors that the cluster_algorithm tries to keep.
+///
+/// The code skeleton notes that the goal is to give the cluster algorithm something to chew on.
+/// The spec itself does not say anything about how this variable is chosen, or why it exists
+/// (but it does define the use of this variable)
+///
+/// Because the input can have fewer than 3 survivors, the MIN_CLUSTER_SURVIVORS
+/// is not an actual lower bound on the number of survivors.
+const MIN_CLUSTER_SURVIVORS: usize = 3;
+
+#[allow(dead_code)]
+fn clock_select(
+    peers: &[Peer],
+    local_clock_time: NtpTimestamp,
+    system_poll: NtpDuration,
+) -> Option<Vec<SurvivorTuple>> {
+    let valid_associations = peers
+        .iter()
+        .filter(|p| p.accept_synchronization(local_clock_time, system_poll));
+
+    let candidates = construct_candidate_list(valid_associations, local_clock_time);
+
+    let mut survivors = construct_survivors(&candidates, local_clock_time);
+
+    if survivors.len() < MIN_INTERSECTION_SURVIVORS {
+        return None;
+    }
+
+    let _system_selection_jitter = cluster_algorithm(&mut survivors);
+
+    Some(survivors)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i8)]
+enum EndpointType {
+    Upper = 1,
+    Middle = 0,
+    Lower = -1,
+}
+
+#[allow(dead_code)]
+struct CandidateTuple<'a> {
+    peer: &'a Peer,
+    endpoint_type: EndpointType,
+    /// Correctness interval edge
+    edge: NtpDuration,
+}
+
+#[allow(dead_code)]
+fn construct_candidate_list<'a>(
+    valid_associations: impl Iterator<Item = &'a Peer>,
+    local_clock_time: NtpTimestamp,
+) -> Vec<CandidateTuple<'a>> {
+    let mut candidate_list = Vec::new();
+
+    for peer in valid_associations {
+        let offset = peer.statistics.offset;
+
+        let tuples = [
+            CandidateTuple {
+                peer,
+                endpoint_type: EndpointType::Upper,
+                edge: offset + peer.root_distance(local_clock_time),
+            },
+            CandidateTuple {
+                peer,
+                endpoint_type: EndpointType::Middle,
+                edge: offset,
+            },
+            CandidateTuple {
+                peer,
+                endpoint_type: EndpointType::Lower,
+                edge: offset - peer.root_distance(local_clock_time),
+            },
+        ];
+
+        candidate_list.extend(tuples)
+    }
+
+    candidate_list.sort_by(|a, b| a.edge.cmp(&b.edge));
+
+    candidate_list
+}
+
+#[allow(dead_code)]
+struct SurvivorTuple<'a> {
+    peer: &'a Peer,
+    metric: NtpDuration,
+}
+
+/// Collect the candidates within the correctness interval
+fn construct_survivors<'a>(
+    chime_list: &[CandidateTuple<'a>],
+    local_clock_time: NtpTimestamp,
+) -> Vec<SurvivorTuple<'a>> {
+    match find_interval(chime_list) {
+        Some((low, high)) => chime_list
+            .iter()
+            .filter_map(|candidate| filter_survivor(candidate, local_clock_time, low, high))
+            .collect(),
+        None => vec![],
+    }
+}
+
+fn filter_survivor<'a>(
+    candidate: &CandidateTuple<'a>,
+    local_clock_time: NtpTimestamp,
+    low: NtpDuration,
+    high: NtpDuration,
+) -> Option<SurvivorTuple<'a>> {
+    // To be a truechimer, a peers middle (actual offset)
+    // needs to lie within the consistency interval.
+    // Note: The standard is unclear on this, but this
+    // is what gives sensible results in combination with
+    // how interval selection works.
+    if candidate.edge < low
+        || candidate.edge > high
+        || candidate.endpoint_type != EndpointType::Middle
+    {
+        None
+    } else {
+        let peer = candidate.peer;
+        let metric = MAX_DISTANCE * peer.last_packet.stratum + peer.root_distance(local_clock_time);
+
+        Some(SurvivorTuple { peer, metric })
+    }
+}
+
+/// Find the largest contiguous intersection of correctness intervals.
+fn find_interval(chime_list: &[CandidateTuple]) -> Option<(NtpDuration, NtpDuration)> {
+    let n = chime_list.len() / 3;
+
+    let mut low = None;
+    let mut high = None;
+
+    // allow is the number of allowed falsetickers
+    for allow in (0..).take_while(|allow| 2 * allow < n) {
+        let mut found = 0; // variable "d", falsetickers found in the current iteration
+        let mut chime = 0; // variable "c"
+
+        // Scan the chime list from lowest to highest to find the lower endpoint.
+        // any middle that we find before the lower endpoint counts as a falseticker
+        for tuple in chime_list {
+            chime -= tuple.endpoint_type as i32;
+
+            // the code skeleton uses `n - found` here, which is wrong!
+            if chime >= (n - allow) as i32 {
+                low = Some(tuple.edge);
+                break;
+            }
+
+            if let EndpointType::Middle = tuple.endpoint_type {
+                found += 1;
+            }
+        }
+
+        // Scan the chime list from highest to lowest to find the upper endpoint.
+        // any middle that we find before the upper endpoint counts as a falseticker
+        chime = 0;
+        for tuple in chime_list.iter().rev() {
+            chime += tuple.endpoint_type as i32;
+
+            // the code skeleton uses `n - found` here, which is wrong!
+            if chime >= (n - allow) as i32 {
+                high = Some(tuple.edge);
+                break;
+            }
+
+            if let EndpointType::Middle = tuple.endpoint_type {
+                found += 1;
+            }
+        }
+
+        // counted more falsetickers than allowed in this iteration;
+        // we loop and try again allowing one more falseticker
+        if found > allow {
+            continue;
+        }
+
+        //  If the intersection is non-empty, declare success.
+        if let (Some(l), Some(h)) = (low, high) {
+            return Some((l, h));
+        }
+    }
+
+    None
+}
+
+/// Discard the survivor with maximum selection jitter until a termination condition is met.
+///
+/// returns the (maximum) selection jitter
+fn cluster_algorithm(candidates: &mut Vec<SurvivorTuple>) -> f64 {
+    // sort the candidates by increasing lambda_p (the merit factor)
+    candidates.sort_by(|a, b| a.metric.cmp(&b.metric));
+
+    loop {
+        let mut qmax_index = 0;
+        let mut min_peer_jitter: f64 = 2.0e9;
+        let mut max_selection_jitter = -2.0e9;
+
+        for (index, candidate) in candidates.iter().enumerate() {
+            let p = candidate.peer;
+
+            min_peer_jitter = f64::min(min_peer_jitter, p.statistics.jitter);
+
+            let selection_jitter_sum = candidates
+                .iter()
+                .map(|q| p.statistics.offset - q.peer.statistics.offset)
+                .map(|delta| delta.to_seconds().powi(2))
+                .sum::<f64>();
+
+            let selection_jitter = (selection_jitter_sum / ((candidates.len() - 1) as f64)).sqrt();
+
+            if selection_jitter > max_selection_jitter {
+                qmax_index = index;
+                max_selection_jitter = selection_jitter;
+            }
+        }
+
+        // If the maximum selection jitter is less than the minimum peer jitter,
+        // Then subsequent iterations will not will not lower the minimum peer jitter,
+        // so we might as well stop.
+        //
+        // To make sure a few survivors are left for the clustering algorithm to chew on, we stop
+        // if the number of survivors is less than or equal to NMIN (3).
+        if max_selection_jitter < min_peer_jitter || candidates.len() <= MIN_CLUSTER_SURVIVORS {
+            // the final version of max_selection_jitter (psi_max in the spec) is
+            // stored under the name "system selection jitter" (PSI_s)
+            return max_selection_jitter;
+        }
+
+        // delete the survivor qmax (the one with the highest jitter) and go around again
+        candidates.remove(qmax_index);
+    }
+}
+
+#[allow(dead_code)]
+struct ClockCombine {
+    system_offset: NtpDuration,
+    system_jitter: NtpDuration,
+}
+
+/// Combine the offsets of the clustering algorithm survivors
+/// using a weighted average with weight determined by the root
+/// distance.  Compute the selection jitter as the weighted RMS
+/// difference between the first survivor and the remaining
+/// survivors.  In some cases, the inherent clock jitter can be
+/// reduced by not using this algorithm, especially when frequent
+/// clockhopping is involved.  The reference implementation can
+/// be configured to avoid this algorithm by designating a
+/// preferred peer.
+///
+/// Assumption: the survivors are the output of the clustering algorithm,
+/// in particular they are in the order produced by the clustering algorithm.
+#[allow(dead_code)]
+fn clock_combine<'a>(
+    survivors: &'a [SurvivorTuple<'a>],
+    selection_jitter: NtpDuration,
+    local_clock_time: NtpTimestamp,
+) -> ClockCombine {
+    let mut y = 0.0; // normalization factor
+    let mut z = 0.0; // weighed offset sum
+
+    for tuple in survivors {
+        let peer = tuple.peer;
+        let x = peer.root_distance(local_clock_time).to_seconds();
+        y += 1.0 / x;
+        z += peer.statistics.offset.to_seconds() / x;
+    }
+
+    let system_offset = NtpDuration::from_seconds(z / y);
+
+    // deviation: the code skeleton does some weird statistics here.
+    // we just pick the jitter of the peer that will become the system peer
+    // this may be an overestimate but that is not a problem
+    let system_peer_jitter = survivors[0].peer.statistics.jitter;
+
+    let system_jitter = NtpDuration::from_seconds(
+        (selection_jitter.to_seconds().powi(2) + system_peer_jitter.powi(2)).sqrt(),
+    );
+
+    ClockCombine {
+        system_offset,
+        system_jitter,
+    }
+}
+
+#[cfg(feature = "fuzz")]
+pub fn fuzz_find_interval(spec: &[(i64, u64)]) {
+    let mut peers = vec![];
+    for _ in 0..spec.len() {
+        peers.push(Peer::test_peer())
+    }
+    let mut candidates = vec![];
+    for (i, (center, size)) in spec.iter().enumerate() {
+        let size = (*size)
+            .min((std::i64::MAX as u64).wrapping_sub(*center as u64))
+            .max((*center as u64).wrapping_sub(std::i64::MIN as u64));
+        candidates.push(CandidateTuple {
+            peer: &peers[i],
+            endpoint_type: EndpointType::Lower,
+            edge: NtpDuration::from_fixed_int((*center).wrapping_sub(size as i64)),
+        });
+        candidates.push(CandidateTuple {
+            peer: &peers[i],
+            endpoint_type: EndpointType::Middle,
+            edge: NtpDuration::from_fixed_int(*center),
+        });
+        candidates.push(CandidateTuple {
+            peer: &peers[i],
+            endpoint_type: EndpointType::Upper,
+            edge: NtpDuration::from_fixed_int((*center).wrapping_add(size as i64)),
+        });
+    }
+    candidates.sort_by(|a, b| a.edge.cmp(&b.edge));
+    let survivors = construct_survivors(&candidates, NtpTimestamp::from_fixed_int(0));
+
+    // check that if we find a cluster, it contains more than half of the peers we work with.
+    assert!(survivors.len() == 0 || 2 * survivors.len() > spec.len());
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn find_interval_simple() {
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-4),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-2),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(0),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(1),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(4),
+            },
+        ];
+
+        assert_eq!(
+            find_interval(&intervals),
+            Some((
+                NtpDuration::from_fixed_int(-2),
+                NtpDuration::from_fixed_int(2)
+            ))
+        );
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 3);
+    }
+
+    #[test]
+    fn find_interval_outlier() {
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-4),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(0),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(15),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(16),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(17),
+            },
+        ];
+
+        assert_eq!(
+            find_interval(&intervals),
+            Some((
+                NtpDuration::from_fixed_int(-3),
+                NtpDuration::from_fixed_int(2)
+            ))
+        );
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 2);
+    }
+
+    #[test]
+    fn find_interval_low_precision_edgecase() {
+        // One larger interval whose middle does not lie in
+        // both smaller intervals, but whose middles do overlap.
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-10),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-2),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(0),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(5),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(6),
+            },
+        ];
+
+        assert_eq!(
+            find_interval(&intervals),
+            Some((
+                NtpDuration::from_fixed_int(-3),
+                NtpDuration::from_fixed_int(5)
+            ))
+        );
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 3);
+    }
+
+    #[test]
+    fn find_interval_interleaving_edgecase() {
+        // Three partially overlapping intervals, where
+        // the outer center's are not in each others interval.
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-5),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-2),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-0),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(1),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(5),
+            },
+        ];
+
+        assert_eq!(
+            find_interval(&intervals),
+            Some((
+                NtpDuration::from_fixed_int(-3),
+                NtpDuration::from_fixed_int(3)
+            ))
+        );
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 3);
+    }
+
+    #[test]
+    fn find_interval_no_consensus() {
+        // Three disjoint intervals
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-4),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(-2),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-0),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(1),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(4),
+            },
+        ];
+
+        assert_eq!(find_interval(&intervals), None);
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 0);
+    }
+
+    #[test]
+    fn find_interval_tiling() {
+        // Three intervals whose midpoints are not in any of the others
+        // but which still overlap somewhat.
+        let peer_1 = Peer::test_peer();
+        let peer_2 = Peer::test_peer();
+        let peer_3 = Peer::test_peer();
+
+        let intervals = [
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-5),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-3),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(-2),
+            },
+            CandidateTuple {
+                peer: &peer_1,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(-1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(-0),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Lower,
+                edge: NtpDuration::from_fixed_int(1),
+            },
+            CandidateTuple {
+                peer: &peer_2,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(2),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Middle,
+                edge: NtpDuration::from_fixed_int(3),
+            },
+            CandidateTuple {
+                peer: &peer_3,
+                endpoint_type: EndpointType::Upper,
+                edge: NtpDuration::from_fixed_int(5),
+            },
+        ];
+
+        assert_eq!(find_interval(&intervals), None);
+
+        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        assert_eq!(survivors.len(), 0);
+    }
+}

--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -7,37 +7,8 @@
 //
 //      https://datatracker.ietf.org/doc/html/rfc5905#appendix-A.5.2
 
-use crate::{packet::NtpLeapIndicator, NtpDuration, NtpHeader, NtpTimestamp, ReferenceId};
-
-const MAX_STRATUM: u8 = 16;
-const MAX_DISTANCE: NtpDuration = NtpDuration::ONE;
-
-// TODO this should be 4 in production?!
-/// Minimum number of survivors needed to be able to discipline the system clock.
-/// More survivors (so more servers from which to get the time) means a more accurate time.
-///
-/// The spec notes (CMIN was renamed to MIN_INTERSECTION_SURVIVORS in our implementation):
-///
-/// > CMIN defines the minimum number of servers consistent with the correctness requirements.
-/// > Suspicious operators would set CMIN to ensure multiple redundant servers are available for the
-/// > algorithms to mitigate properly. However, for historic reasons the default value for CMIN is one.
-const MIN_INTERSECTION_SURVIVORS: usize = 1;
-
-/// Number of survivors that the cluster_algorithm tries to keep.
-///
-/// The code skeleton notes that the goal is to give the cluster algorithm something to chew on.
-/// The spec itself does not say anything about how this variable is chosen, or why it exists
-/// (but it does define the use of this variable)
-///
-/// Because the input can have fewer than 3 survivors, the MIN_CLUSTER_SURVIVORS
-/// is not an actual lower bound on the number of survivors.
-const MIN_CLUSTER_SURVIVORS: usize = 3;
-
-/// frequency tolerance (15 ppm)
-// const PHI: f64 = 15e-6;
-fn multiply_by_phi(duration: NtpDuration) -> NtpDuration {
-    (duration * 15) / 1_000_000
-}
+use crate::peer::{multiply_by_phi, PeerStatistics};
+use crate::{packet::NtpLeapIndicator, NtpDuration, NtpTimestamp};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FilterTuple {
@@ -61,7 +32,7 @@ impl FilterTuple {
 }
 
 #[derive(Debug, Clone)]
-pub struct LastMeasurements {
+pub(crate) struct LastMeasurements {
     register: [FilterTuple; 8],
 }
 
@@ -91,11 +62,49 @@ impl LastMeasurements {
             std::mem::swap(&mut current, tuple);
         }
     }
+
+    pub(crate) fn step(
+        &mut self,
+        new_tuple: FilterTuple,
+        peer_time: NtpTimestamp,
+        system_leap_indicator: NtpLeapIndicator,
+        system_precision: f64,
+    ) -> Option<(PeerStatistics, NtpTimestamp)> {
+        let dispersion_correction = multiply_by_phi(new_tuple.time - peer_time);
+        self.shift_and_insert(new_tuple, dispersion_correction);
+
+        let temporary_list = TemporaryList::from_clock_filter_contents(self);
+        let smallest_delay = *temporary_list.smallest_delay();
+
+        // Prime directive: use a sample only once and never a sample
+        // older than the latest one, but anything goes before first
+        // synchronized.
+        if smallest_delay.time - peer_time <= NtpDuration::ZERO
+            && system_leap_indicator.is_synchronized()
+        {
+            return None;
+        }
+
+        let offset = smallest_delay.offset;
+        let delay = smallest_delay.delay;
+
+        let dispersion = temporary_list.dispersion();
+        let jitter = temporary_list.jitter(smallest_delay, system_precision);
+
+        let statistics = PeerStatistics {
+            offset,
+            delay,
+            dispersion,
+            jitter,
+        };
+
+        Some((statistics, smallest_delay.time))
+    }
 }
 
 /// Temporary list
 #[derive(Debug, Clone)]
-struct TemporaryList {
+pub(crate) struct TemporaryList {
     /// Invariant: this array is always sorted by increasing delay!
     register: [FilterTuple; 8],
 }
@@ -192,486 +201,6 @@ impl TemporaryList {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct PeerStatistics {
-    pub offset: NtpDuration,
-    pub delay: NtpDuration,
-
-    pub dispersion: NtpDuration,
-    pub jitter: f64,
-}
-
-pub struct Peer {
-    statistics: PeerStatistics,
-    last_measurements: LastMeasurements,
-    last_packet: NtpHeader,
-    time: NtpTimestamp,
-    #[allow(dead_code)]
-    peer_id: ReferenceId,
-    our_id: ReferenceId,
-    #[allow(dead_code)]
-    reach: Reach,
-}
-
-/// Used to determine whether the server is reachable and the data are fresh
-///
-/// This value is represented as an 8-bit shift register. The register is shifted left
-/// by one bit when a packet is sent and the rightmost bit is set to zero.  
-/// As valid packets arrive, the rightmost bit is set to one.
-/// If the register contains any nonzero bits, the server is considered reachable;
-/// otherwise, it is unreachable.
-#[derive(Debug, Default)]
-struct Reach(u8);
-
-impl Reach {
-    #[allow(dead_code)]
-    fn is_reachable(&self) -> bool {
-        self.0 != 0
-    }
-
-    /// We have just received a packet, so the peer is definitely reachable
-    #[allow(dead_code)]
-    fn received_packet(&mut self) {
-        self.0 |= 1;
-    }
-
-    /// A packet received some number of poll intervals ago is decreasingly relevant for
-    /// determining that a peer is still reachable. We discount the packets received so far.
-    #[allow(dead_code)]
-    fn poll(&mut self) {
-        self.0 <<= 1
-    }
-}
-
-pub enum Decision {
-    Ignore,
-    Process,
-}
-
-impl Peer {
-    #[allow(dead_code)]
-    pub fn clock_filter(
-        &mut self,
-        new_tuple: FilterTuple,
-        system_leap_indicator: NtpLeapIndicator,
-        system_precision: f64,
-    ) -> Decision {
-        let dispersion_correction = multiply_by_phi(new_tuple.time - self.time);
-        self.last_measurements
-            .shift_and_insert(new_tuple, dispersion_correction);
-
-        let temporary_list = TemporaryList::from_clock_filter_contents(&self.last_measurements);
-        let smallest_delay = *temporary_list.smallest_delay();
-
-        // Prime directive: use a sample only once and never a sample
-        // older than the latest one, but anything goes before first
-        // synchronized.
-        if smallest_delay.time - self.time <= NtpDuration::ZERO
-            && system_leap_indicator.is_synchronized()
-        {
-            return Decision::Ignore;
-        }
-
-        let offset = smallest_delay.offset;
-        let delay = smallest_delay.delay;
-
-        let dispersion = temporary_list.dispersion();
-        let jitter = temporary_list.jitter(smallest_delay, system_precision);
-
-        let statistics = PeerStatistics {
-            offset,
-            delay,
-            dispersion,
-            jitter,
-        };
-
-        self.statistics = statistics;
-        self.time = smallest_delay.time;
-
-        Decision::Process
-    }
-
-    /// The root synchronization distance is the maximum error due to
-    /// all causes of the local clock relative to the primary server.
-    /// It is defined as half the total delay plus total dispersion
-    /// plus peer jitter.
-    #[allow(dead_code)]
-    fn root_distance(&self, local_clock_time: NtpTimestamp) -> NtpDuration {
-        NtpDuration::MIN_DISPERSION.max(self.last_packet.root_delay + self.statistics.delay) / 2i64
-            + self.last_packet.root_dispersion
-            + self.statistics.dispersion
-            + multiply_by_phi(local_clock_time - self.time)
-            + NtpDuration::from_seconds(self.statistics.jitter)
-    }
-
-    #[allow(dead_code)]
-    /// Test if association p is acceptable for synchronization
-    ///
-    /// Known as `accept` and `fit` in the specification.
-    fn accept_synchronization(
-        &self,
-        local_clock_time: NtpTimestamp,
-        system_poll: NtpDuration,
-    ) -> bool {
-        // A stratum error occurs if
-        //     1: the server has never been synchronized,
-        //     2: the server stratum is invalid
-        if !self.last_packet.leap.is_synchronized() || self.last_packet.stratum >= MAX_STRATUM {
-            return false;
-        }
-
-        //  A distance error occurs if the root distance exceeds the
-        //  distance threshold plus an increment equal to one poll interval.
-        let distance = self.root_distance(local_clock_time);
-
-        if distance > MAX_DISTANCE + multiply_by_phi(system_poll) {
-            return false;
-        }
-
-        // Detect whether the remote uses us as their main time reference.
-        // if so, we shouldn't sync to them as that would create a loop.
-        // Note, this can only ever be an issue if the peer is not using
-        // hardware as its source, so ignore reference_id if stratum is 1.
-        if self.last_packet.stratum != 1 && self.last_packet.reference_id == self.our_id {
-            return false;
-        }
-
-        // An unreachable error occurs if the server is unreachable.
-        if !self.reach.is_reachable() {
-            return false;
-        }
-
-        true
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(i8)]
-enum EndpointType {
-    Upper = 1,
-    Middle = 0,
-    Lower = -1,
-}
-
-#[allow(dead_code)]
-struct CandidateTuple<'a> {
-    peer: &'a Peer,
-    endpoint_type: EndpointType,
-    /// Correctness interval edge
-    edge: NtpDuration,
-}
-
-#[allow(dead_code)]
-fn construct_candidate_list<'a>(
-    valid_associations: impl Iterator<Item = &'a Peer>,
-    local_clock_time: NtpTimestamp,
-) -> Vec<CandidateTuple<'a>> {
-    let mut candidate_list = Vec::new();
-
-    for peer in valid_associations {
-        let offset = peer.statistics.offset;
-
-        let tuples = [
-            CandidateTuple {
-                peer,
-                endpoint_type: EndpointType::Upper,
-                edge: offset + peer.root_distance(local_clock_time),
-            },
-            CandidateTuple {
-                peer,
-                endpoint_type: EndpointType::Middle,
-                edge: offset,
-            },
-            CandidateTuple {
-                peer,
-                endpoint_type: EndpointType::Lower,
-                edge: offset - peer.root_distance(local_clock_time),
-            },
-        ];
-
-        candidate_list.extend(tuples)
-    }
-
-    candidate_list.sort_by(|a, b| a.edge.cmp(&b.edge));
-
-    candidate_list
-}
-
-#[allow(dead_code)]
-struct SurvivorTuple<'a> {
-    peer: &'a Peer,
-    metric: NtpDuration,
-}
-
-/// Collect the candidates within the correctness interval
-#[allow(dead_code)]
-fn construct_survivors<'a>(
-    chime_list: &[CandidateTuple<'a>],
-    local_clock_time: NtpTimestamp,
-) -> Vec<SurvivorTuple<'a>> {
-    match find_interval(chime_list) {
-        Some((low, high)) => chime_list
-            .iter()
-            .filter_map(|candidate| filter_survivor(candidate, local_clock_time, low, high))
-            .collect(),
-        None => vec![],
-    }
-}
-
-fn filter_survivor<'a>(
-    candidate: &CandidateTuple<'a>,
-    local_clock_time: NtpTimestamp,
-    low: NtpDuration,
-    high: NtpDuration,
-) -> Option<SurvivorTuple<'a>> {
-    // To be a truechimer, a peers middle (actual offset)
-    // needs to lie within the consistency interval.
-    // Note: The standard is unclear on this, but this
-    // is what gives sensible results in combination with
-    // how interval selection works.
-    if candidate.edge < low
-        || candidate.edge > high
-        || candidate.endpoint_type != EndpointType::Middle
-    {
-        None
-    } else {
-        let peer = candidate.peer;
-        let metric = MAX_DISTANCE * peer.last_packet.stratum + peer.root_distance(local_clock_time);
-
-        Some(SurvivorTuple { peer, metric })
-    }
-}
-
-/// Find the largest contiguous intersection of correctness intervals.
-#[allow(dead_code)]
-fn find_interval(chime_list: &[CandidateTuple]) -> Option<(NtpDuration, NtpDuration)> {
-    let n = chime_list.len() / 3;
-
-    let mut low = None;
-    let mut high = None;
-
-    // allow is the number of allowed falsetickers
-    for allow in (0..).take_while(|allow| 2 * allow < n) {
-        let mut found = 0; // variable "d", falsetickers found in the current iteration
-        let mut chime = 0; // variable "c"
-
-        // Scan the chime list from lowest to highest to find the lower endpoint.
-        // any middle that we find before the lower endpoint counts as a falseticker
-        for tuple in chime_list {
-            chime -= tuple.endpoint_type as i32;
-
-            // the code skeleton uses `n - found` here, which is wrong!
-            if chime >= (n - allow) as i32 {
-                low = Some(tuple.edge);
-                break;
-            }
-
-            if let EndpointType::Middle = tuple.endpoint_type {
-                found += 1;
-            }
-        }
-
-        // Scan the chime list from highest to lowest to find the upper endpoint.
-        // any middle that we find before the upper endpoint counts as a falseticker
-        chime = 0;
-        for tuple in chime_list.iter().rev() {
-            chime += tuple.endpoint_type as i32;
-
-            // the code skeleton uses `n - found` here, which is wrong!
-            if chime >= (n - allow) as i32 {
-                high = Some(tuple.edge);
-                break;
-            }
-
-            if let EndpointType::Middle = tuple.endpoint_type {
-                found += 1;
-            }
-        }
-
-        // counted more falsetickers than allowed in this iteration;
-        // we loop and try again allowing one more falseticker
-        if found > allow {
-            continue;
-        }
-
-        //  If the intersection is non-empty, declare success.
-        if let (Some(l), Some(h)) = (low, high) {
-            return Some((l, h));
-        }
-    }
-
-    None
-}
-
-/// Discard the survivor with maximum selection jitter until a termination condition is met.
-///
-/// returns the (maximum) selection jitter
-fn cluster_algorithm(candidates: &mut Vec<SurvivorTuple>) -> f64 {
-    // sort the candidates by increasing lambda_p (the merit factor)
-    candidates.sort_by(|a, b| a.metric.cmp(&b.metric));
-
-    loop {
-        let mut qmax_index = 0;
-        let mut min_peer_jitter: f64 = 2.0e9;
-        let mut max_selection_jitter = -2.0e9;
-
-        for (index, candidate) in candidates.iter().enumerate() {
-            let p = candidate.peer;
-
-            min_peer_jitter = f64::min(min_peer_jitter, p.statistics.jitter);
-
-            let selection_jitter_sum = candidates
-                .iter()
-                .map(|q| p.statistics.offset - q.peer.statistics.offset)
-                .map(|delta| delta.to_seconds().powi(2))
-                .sum::<f64>();
-
-            let selection_jitter = (selection_jitter_sum / ((candidates.len() - 1) as f64)).sqrt();
-
-            if selection_jitter > max_selection_jitter {
-                qmax_index = index;
-                max_selection_jitter = selection_jitter;
-            }
-        }
-
-        // If the maximum selection jitter is less than the minimum peer jitter,
-        // Then subsequent iterations will not will not lower the minimum peer jitter,
-        // so we might as well stop.
-        //
-        // To make sure a few survivors are left for the clustering algorithm to chew on, we stop
-        // if the number of survivors is less than or equal to NMIN (3).
-        if max_selection_jitter < min_peer_jitter || candidates.len() <= MIN_CLUSTER_SURVIVORS {
-            // the final version of max_selection_jitter (psi_max in the spec) is
-            // stored under the name "system selection jitter" (PSI_s)
-            return max_selection_jitter;
-        }
-
-        // delete the survivor qmax (the one with the highest jitter) and go around again
-        candidates.remove(qmax_index);
-    }
-}
-
-#[allow(dead_code)]
-fn clock_select(
-    peers: &[Peer],
-    local_clock_time: NtpTimestamp,
-    system_poll: NtpDuration,
-) -> Option<Vec<SurvivorTuple>> {
-    let valid_associations = peers
-        .iter()
-        .filter(|p| p.accept_synchronization(local_clock_time, system_poll));
-
-    let candidates = construct_candidate_list(valid_associations, local_clock_time);
-
-    let mut survivors = construct_survivors(&candidates, local_clock_time);
-
-    if survivors.len() < MIN_INTERSECTION_SURVIVORS {
-        return None;
-    }
-
-    let _system_selection_jitter = cluster_algorithm(&mut survivors);
-
-    Some(survivors)
-}
-
-#[allow(dead_code)]
-struct ClockCombine {
-    system_offset: NtpDuration,
-    system_jitter: NtpDuration,
-}
-
-/// Combine the offsets of the clustering algorithm survivors
-/// using a weighted average with weight determined by the root
-/// distance.  Compute the selection jitter as the weighted RMS
-/// difference between the first survivor and the remaining
-/// survivors.  In some cases, the inherent clock jitter can be
-/// reduced by not using this algorithm, especially when frequent
-/// clockhopping is involved.  The reference implementation can
-/// be configured to avoid this algorithm by designating a
-/// preferred peer.
-///
-/// Assumption: the survivors are the output of the clustering algorithm,
-/// in particular they are in the order produced by the clustering algorithm.
-#[allow(dead_code)]
-fn clock_combine<'a>(
-    survivors: &'a [SurvivorTuple<'a>],
-    selection_jitter: NtpDuration,
-    local_clock_time: NtpTimestamp,
-) -> ClockCombine {
-    let mut y = 0.0; // normalization factor
-    let mut z = 0.0; // weighed offset sum
-
-    for tuple in survivors {
-        let peer = tuple.peer;
-        let x = peer.root_distance(local_clock_time).to_seconds();
-        y += 1.0 / x;
-        z += peer.statistics.offset.to_seconds() / x;
-    }
-
-    let system_offset = NtpDuration::from_seconds(z / y);
-
-    // deviation: the code skeleton does some weird statistics here.
-    // we just pick the jitter of the peer that will become the system peer
-    // this may be an overestimate but that is not a problem
-    let system_peer_jitter = survivors[0].peer.statistics.jitter;
-
-    let system_jitter = NtpDuration::from_seconds(
-        (selection_jitter.to_seconds().powi(2) + system_peer_jitter.powi(2)).sqrt(),
-    );
-
-    ClockCombine {
-        system_offset,
-        system_jitter,
-    }
-}
-
-#[cfg(any(test, feature = "fuzz"))]
-fn default_peer() -> Peer {
-    Peer {
-        statistics: Default::default(),
-        last_measurements: Default::default(),
-        last_packet: Default::default(),
-        time: Default::default(),
-        peer_id: ReferenceId::from_int(0),
-        our_id: ReferenceId::from_int(0),
-        reach: Reach::default(),
-    }
-}
-
-#[cfg(feature = "fuzz")]
-pub fn fuzz_find_interval(spec: &[(i64, u64)]) {
-    let mut peers = vec![];
-    for _ in 0..spec.len() {
-        peers.push(default_peer())
-    }
-    let mut candidates = vec![];
-    for (i, (center, size)) in spec.iter().enumerate() {
-        let size = (*size)
-            .min((std::i64::MAX as u64).wrapping_sub(*center as u64))
-            .max((*center as u64).wrapping_sub(std::i64::MIN as u64));
-        candidates.push(CandidateTuple {
-            peer: &peers[i],
-            endpoint_type: EndpointType::Lower,
-            edge: NtpDuration::from_fixed_int((*center).wrapping_sub(size as i64)),
-        });
-        candidates.push(CandidateTuple {
-            peer: &peers[i],
-            endpoint_type: EndpointType::Middle,
-            edge: NtpDuration::from_fixed_int(*center),
-        });
-        candidates.push(CandidateTuple {
-            peer: &peers[i],
-            endpoint_type: EndpointType::Upper,
-            edge: NtpDuration::from_fixed_int((*center).wrapping_add(size as i64)),
-        });
-    }
-    candidates.sort_by(|a, b| a.edge.cmp(&b.edge));
-    let survivors = construct_survivors(&candidates, NtpTimestamp::from_fixed_int(0));
-
-    // check that if we find a cluster, it contains more than half of the peers we work with.
-    assert!(survivors.len() == 0 || 2 * survivors.len() > spec.len());
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -729,9 +258,6 @@ mod test {
 
     #[test]
     fn clock_filter_defaults() {
-        let leap_indicator = NtpLeapIndicator::NoWarning;
-        let system_precision = 0.0;
-
         let new_tuple = FilterTuple {
             offset: Default::default(),
             delay: Default::default(),
@@ -739,20 +265,25 @@ mod test {
             time: Default::default(),
         };
 
-        let mut peer = default_peer();
+        let mut measurements = LastMeasurements::default();
 
-        let update = peer.clock_filter(new_tuple, leap_indicator, system_precision);
+        let peer_time = NtpTimestamp::default();
+        let system_leap_indicator = NtpLeapIndicator::NoWarning;
+        let system_precision = 0.0;
+        let update = measurements.step(
+            new_tuple,
+            peer_time,
+            system_leap_indicator,
+            system_precision,
+        );
 
         // because "time" is zero, the same as all the dummy tuples,
         // the "new" tuple is not newer and hence rejected
-        assert!(matches!(update, Decision::Ignore));
+        assert!(update.is_none());
     }
 
     #[test]
     fn clock_filter_new() {
-        let leap_indicator = NtpLeapIndicator::NoWarning;
-        let system_precision = 0.0;
-
         let new_tuple = FilterTuple {
             offset: NtpDuration::from_seconds(12.0),
             delay: NtpDuration::from_seconds(14.0),
@@ -760,568 +291,32 @@ mod test {
             time: NtpTimestamp::from_bits((1i64 << 32).to_be_bytes()),
         };
 
-        let mut peer = default_peer();
+        let mut measurements = LastMeasurements::default();
 
-        let update = peer.clock_filter(new_tuple, leap_indicator, system_precision);
+        let peer_time = NtpTimestamp::default();
+        let system_leap_indicator = NtpLeapIndicator::NoWarning;
+        let system_precision = 0.0;
+        let update = measurements.step(
+            new_tuple,
+            peer_time,
+            system_leap_indicator,
+            system_precision,
+        );
 
-        assert!(matches!(update, Decision::Process));
+        assert!(update.is_some());
 
-        assert_eq!(peer.statistics.offset, new_tuple.offset);
-        assert_eq!(peer.statistics.delay, new_tuple.delay);
-        assert_eq!(peer.time, new_tuple.time);
+        let (statistics, new_time) = update.unwrap();
+
+        assert_eq!(statistics.offset, new_tuple.offset);
+        assert_eq!(statistics.delay, new_tuple.delay);
+        assert_eq!(new_time, new_tuple.time);
 
         // there is just one valid sample
-        assert_eq!(peer.statistics.jitter, 0.0);
+        assert_eq!(statistics.jitter, 0.0);
 
-        let temporary = TemporaryList::from_clock_filter_contents(&peer.last_measurements);
+        let temporary = TemporaryList::from_clock_filter_contents(&measurements);
 
         assert_eq!(temporary.register[0], new_tuple);
         assert_eq!(temporary.valid_tuples(), &[new_tuple]);
-    }
-
-    #[test]
-    fn test_root_duration_sanity() {
-        // Ensure root distance at least increases as it is supposed to
-        // when changing the main measurement parameters
-        let mut packet = NtpHeader::new();
-        packet.root_delay = NtpDuration::from_fixed_int(100000000);
-        packet.root_dispersion = NtpDuration::from_fixed_int(100000000);
-        let reference = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < reference.root_distance(NtpTimestamp::from_fixed_int(200000000))
-        );
-
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(200000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(200000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(0),
-            ..default_peer()
-        };
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-
-        packet.root_delay = NtpDuration::from_fixed_int(200000000);
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-        packet.root_delay = NtpDuration::from_fixed_int(100000000);
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-
-        packet.root_dispersion = NtpDuration::from_fixed_int(200000000);
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-        packet.root_dispersion = NtpDuration::from_fixed_int(100000000);
-        assert!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000))
-                < sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-
-        let sample = Peer {
-            statistics: PeerStatistics {
-                delay: NtpDuration::from_fixed_int(100000000),
-                dispersion: NtpDuration::from_fixed_int(100000000),
-                ..Default::default()
-            },
-            last_measurements: Default::default(),
-            last_packet: packet.clone(),
-            time: NtpTimestamp::from_fixed_int(100000000),
-            ..default_peer()
-        };
-        assert_eq!(
-            reference.root_distance(NtpTimestamp::from_fixed_int(100000000)),
-            sample.root_distance(NtpTimestamp::from_fixed_int(100000000))
-        );
-    }
-
-    #[test]
-    fn find_interval_simple() {
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-4),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-2),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(0),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(1),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(4),
-            },
-        ];
-
-        assert_eq!(
-            find_interval(&intervals),
-            Some((
-                NtpDuration::from_fixed_int(-2),
-                NtpDuration::from_fixed_int(2)
-            ))
-        );
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 3);
-    }
-
-    #[test]
-    fn find_interval_outlier() {
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-4),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(0),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(15),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(16),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(17),
-            },
-        ];
-
-        assert_eq!(
-            find_interval(&intervals),
-            Some((
-                NtpDuration::from_fixed_int(-3),
-                NtpDuration::from_fixed_int(2)
-            ))
-        );
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 2);
-    }
-
-    #[test]
-    fn find_interval_low_precision_edgecase() {
-        // One larger interval whose middle does not lie in
-        // both smaller intervals, but whose middles do overlap.
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-10),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-2),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(0),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(5),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(6),
-            },
-        ];
-
-        assert_eq!(
-            find_interval(&intervals),
-            Some((
-                NtpDuration::from_fixed_int(-3),
-                NtpDuration::from_fixed_int(5)
-            ))
-        );
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 3);
-    }
-
-    #[test]
-    fn find_interval_interleaving_edgecase() {
-        // Three partially overlapping intervals, where
-        // the outer center's are not in each others interval.
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-5),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-2),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-0),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(1),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(5),
-            },
-        ];
-
-        assert_eq!(
-            find_interval(&intervals),
-            Some((
-                NtpDuration::from_fixed_int(-3),
-                NtpDuration::from_fixed_int(3)
-            ))
-        );
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 3);
-    }
-
-    #[test]
-    fn find_interval_no_consensus() {
-        // Three disjoint intervals
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-4),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(-2),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-0),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(1),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(4),
-            },
-        ];
-
-        assert_eq!(find_interval(&intervals), None);
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 0);
-    }
-
-    #[test]
-    fn find_interval_tiling() {
-        // Three intervals whose midpoints are not in any of the others
-        // but which still overlap somewhat.
-        let peer_1 = default_peer();
-        let peer_2 = default_peer();
-        let peer_3 = default_peer();
-
-        let intervals = [
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-5),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-3),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(-2),
-            },
-            CandidateTuple {
-                peer: &peer_1,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(-1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(-0),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Lower,
-                edge: NtpDuration::from_fixed_int(1),
-            },
-            CandidateTuple {
-                peer: &peer_2,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(2),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Middle,
-                edge: NtpDuration::from_fixed_int(3),
-            },
-            CandidateTuple {
-                peer: &peer_3,
-                endpoint_type: EndpointType::Upper,
-                edge: NtpDuration::from_fixed_int(5),
-            },
-        ];
-
-        assert_eq!(find_interval(&intervals), None);
-
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
-        assert_eq!(survivors.len(), 0);
-    }
-
-    #[test]
-    fn reachability() {
-        let mut reach = Reach::default();
-
-        // the default reach register value is 0, and hence not reachable
-        assert!(!reach.is_reachable());
-
-        // when we receive a packet, we set the right-most bit;
-        // we just received a packet from the peer, so it is reachable
-        reach.received_packet();
-        assert!(reach.is_reachable());
-
-        // on every poll, the register is shifted to the left, and there are
-        // 8 bits. So we can poll 7 times and the peer is still considered reachable
-        for _ in 0..7 {
-            reach.poll();
-        }
-
-        assert!(reach.is_reachable());
-
-        // but one more poll and all 1 bits have been shifted out;
-        // the peer is no longer reachable
-        reach.poll();
-        assert!(!reach.is_reachable());
-
-        // until we receive a packet from it again
-        reach.received_packet();
-        assert!(reach.is_reachable());
     }
 }

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -10,7 +10,7 @@ mod time_types;
 
 pub use clock::NtpClock;
 #[cfg(feature = "fuzz")]
-pub use filter::fuzz_find_interval;
+pub use clock_select::fuzz_find_interval;
 pub use identifiers::ReferenceId;
 pub use packet::NtpHeader;
 pub use time_types::{NtpDuration, NtpTimestamp};

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -1,9 +1,11 @@
 #![forbid(unsafe_code)]
 
 mod clock;
+mod clock_select;
 mod filter;
 mod identifiers;
 mod packet;
+mod peer;
 mod time_types;
 
 pub use clock::NtpClock;

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -1,0 +1,306 @@
+use crate::{
+    filter::{FilterTuple, LastMeasurements},
+    packet::NtpLeapIndicator,
+    NtpDuration, NtpHeader, NtpTimestamp, ReferenceId,
+};
+
+const MAX_STRATUM: u8 = 16;
+pub(crate) const MAX_DISTANCE: NtpDuration = NtpDuration::ONE;
+
+/// frequency tolerance (15 ppm)
+// const PHI: f64 = 15e-6;
+pub(crate) fn multiply_by_phi(duration: NtpDuration) -> NtpDuration {
+    (duration * 15) / 1_000_000
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PeerStatistics {
+    pub offset: NtpDuration,
+    pub delay: NtpDuration,
+
+    pub dispersion: NtpDuration,
+    pub jitter: f64,
+}
+
+pub(crate) struct Peer {
+    pub statistics: PeerStatistics,
+    pub last_measurements: LastMeasurements,
+    pub last_packet: NtpHeader,
+    pub time: NtpTimestamp,
+    #[allow(dead_code)]
+    pub peer_id: ReferenceId,
+    pub our_id: ReferenceId,
+    #[allow(dead_code)]
+    pub reach: Reach,
+}
+
+/// Used to determine whether the server is reachable and the data are fresh
+///
+/// This value is represented as an 8-bit shift register. The register is shifted left
+/// by one bit when a packet is sent and the rightmost bit is set to zero.  
+/// As valid packets arrive, the rightmost bit is set to one.
+/// If the register contains any nonzero bits, the server is considered reachable;
+/// otherwise, it is unreachable.
+#[derive(Debug, Default)]
+pub(crate) struct Reach(u8);
+
+impl Reach {
+    #[allow(dead_code)]
+    fn is_reachable(&self) -> bool {
+        self.0 != 0
+    }
+
+    /// We have just received a packet, so the peer is definitely reachable
+    #[allow(dead_code)]
+    fn received_packet(&mut self) {
+        self.0 |= 1;
+    }
+
+    /// A packet received some number of poll intervals ago is decreasingly relevant for
+    /// determining that a peer is still reachable. We discount the packets received so far.
+    #[allow(dead_code)]
+    fn poll(&mut self) {
+        self.0 <<= 1
+    }
+}
+
+pub enum Decision {
+    Ignore,
+    Process,
+}
+
+impl Peer {
+    #[allow(dead_code)]
+    pub(crate) fn clock_filter(
+        &mut self,
+        new_tuple: FilterTuple,
+        system_leap_indicator: NtpLeapIndicator,
+        system_precision: f64,
+    ) -> Decision {
+        let updated = self.last_measurements.step(
+            new_tuple,
+            self.time,
+            system_leap_indicator,
+            system_precision,
+        );
+
+        match updated {
+            None => Decision::Ignore,
+            Some((statistics, smallest_delay_time)) => {
+                self.statistics = statistics;
+                self.time = smallest_delay_time;
+
+                Decision::Process
+            }
+        }
+    }
+
+    /// The root synchronization distance is the maximum error due to
+    /// all causes of the local clock relative to the primary server.
+    /// It is defined as half the total delay plus total dispersion
+    /// plus peer jitter.
+    #[allow(dead_code)]
+    pub(crate) fn root_distance(&self, local_clock_time: NtpTimestamp) -> NtpDuration {
+        NtpDuration::MIN_DISPERSION.max(self.last_packet.root_delay + self.statistics.delay) / 2i64
+            + self.last_packet.root_dispersion
+            + self.statistics.dispersion
+            + multiply_by_phi(local_clock_time - self.time)
+            + NtpDuration::from_seconds(self.statistics.jitter)
+    }
+
+    #[allow(dead_code)]
+    /// Test if association p is acceptable for synchronization
+    ///
+    /// Known as `accept` and `fit` in the specification.
+    pub(crate) fn accept_synchronization(
+        &self,
+        local_clock_time: NtpTimestamp,
+        system_poll: NtpDuration,
+    ) -> bool {
+        // A stratum error occurs if
+        //     1: the server has never been synchronized,
+        //     2: the server stratum is invalid
+        if !self.last_packet.leap.is_synchronized() || self.last_packet.stratum >= MAX_STRATUM {
+            return false;
+        }
+
+        //  A distance error occurs if the root distance exceeds the
+        //  distance threshold plus an increment equal to one poll interval.
+        let distance = self.root_distance(local_clock_time);
+
+        if distance > MAX_DISTANCE + multiply_by_phi(system_poll) {
+            return false;
+        }
+
+        // Detect whether the remote uses us as their main time reference.
+        // if so, we shouldn't sync to them as that would create a loop.
+        // Note, this can only ever be an issue if the peer is not using
+        // hardware as its source, so ignore reference_id if stratum is 1.
+        if self.last_packet.stratum != 1 && self.last_packet.reference_id == self.our_id {
+            return false;
+        }
+
+        // An unreachable error occurs if the server is unreachable.
+        if !self.reach.is_reachable() {
+            return false;
+        }
+
+        true
+    }
+
+    #[cfg(any(test, feature = "fuzz"))]
+    pub(crate) fn test_peer() -> Peer {
+        Peer {
+            statistics: Default::default(),
+            last_measurements: Default::default(),
+            last_packet: Default::default(),
+            time: Default::default(),
+            peer_id: ReferenceId::from_int(0),
+            our_id: ReferenceId::from_int(0),
+            reach: Reach::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_root_duration_sanity() {
+        // Ensure root distance at least increases as it is supposed to
+        // when changing the main measurement parameters
+
+        let duration_1s = NtpDuration::from_fixed_int(1_0000_0000);
+        let duration_2s = NtpDuration::from_fixed_int(2_0000_0000);
+
+        let timestamp_1s = NtpTimestamp::from_fixed_int(1_0000_0000);
+        let timestamp_2s = NtpTimestamp::from_fixed_int(2_0000_0000);
+
+        let mut packet = NtpHeader::new();
+        packet.root_delay = duration_1s;
+        packet.root_dispersion = duration_1s;
+        let reference = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+
+        assert!(reference.root_distance(timestamp_1s) < reference.root_distance(timestamp_2s));
+
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_2s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+        assert!(reference.root_distance(timestamp_1s) < sample.root_distance(timestamp_1s));
+
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_2s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+        assert!(reference.root_distance(timestamp_1s) < sample.root_distance(timestamp_1s));
+
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: NtpTimestamp::from_fixed_int(0),
+            ..Peer::test_peer()
+        };
+        assert!(reference.root_distance(timestamp_1s) < sample.root_distance(timestamp_1s));
+
+        packet.root_delay = duration_2s;
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+        packet.root_delay = duration_1s;
+        assert!(reference.root_distance(timestamp_1s) < sample.root_distance(timestamp_1s));
+
+        packet.root_dispersion = duration_2s;
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+        packet.root_dispersion = duration_1s;
+        assert!(reference.root_distance(timestamp_1s) < sample.root_distance(timestamp_1s));
+
+        let sample = Peer {
+            statistics: PeerStatistics {
+                delay: duration_1s,
+                dispersion: duration_1s,
+                ..Default::default()
+            },
+            last_packet: packet,
+            time: timestamp_1s,
+            ..Peer::test_peer()
+        };
+
+        assert_eq!(
+            reference.root_distance(timestamp_1s),
+            sample.root_distance(timestamp_1s)
+        );
+    }
+
+    #[test]
+    fn reachability() {
+        let mut reach = Reach::default();
+
+        // the default reach register value is 0, and hence not reachable
+        assert!(!reach.is_reachable());
+
+        // when we receive a packet, we set the right-most bit;
+        // we just received a packet from the peer, so it is reachable
+        reach.received_packet();
+        assert!(reach.is_reachable());
+
+        // on every poll, the register is shifted to the left, and there are
+        // 8 bits. So we can poll 7 times and the peer is still considered reachable
+        for _ in 0..7 {
+            reach.poll();
+        }
+
+        assert!(reach.is_reachable());
+
+        // but one more poll and all 1 bits have been shifted out;
+        // the peer is no longer reachable
+        reach.poll();
+        assert!(!reach.is_reachable());
+
+        // until we receive a packet from it again
+        reach.received_packet();
+        assert!(reach.is_reachable());
+    }
+}

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -22,6 +22,7 @@ pub(crate) struct PeerStatistics {
     pub jitter: f64,
 }
 
+#[derive(Debug)]
 pub(crate) struct Peer {
     pub statistics: PeerStatistics,
     pub last_measurements: LastMeasurements,


### PR DESCRIPTION
`pub(crate)` all the things. 

This seems to generally work well. The one thing I'm not entirely sure on is where `PeerStatistics` should live. I know that in rust you can have circular dependencies between modules, but intuitively I dislike that. Right now there is still a circular dependency between `peer.rs` and `filter.rs`