### PR TITLE
split "hardware" and "ntp server" clock domains

### DIFF
--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use ntp_proto::{
-    NtpClock, NtpDuration, NtpHeader, Peer, PeerSnapshot, ReferenceId, SystemSnapshot,
+    NtpClock, NtpDuration, NtpHeader, NtpInstant, Peer, PeerSnapshot, ReferenceId, SystemSnapshot,
 };
 use tokio::{
     net::{ToSocketAddrs, UdpSocket},
@@ -33,7 +33,8 @@ pub async fn start_peer<A: ToSocketAddrs, C: 'static + NtpClock + Send>(
     let socket = ntp_udp::UdpSocket::from_tokio(socket)?;
 
     tokio::spawn(async move {
-        let mut peer = Peer::new(our_id, peer_id, clock.now().unwrap());
+        let local_clock_time = NtpInstant::from_ntp_timestamp(clock.now().unwrap());
+        let mut peer = Peer::new(our_id, peer_id, local_clock_time);
 
         let poll_interval = {
             let system_snapshot = system_snapshots.borrow_and_update();
@@ -56,7 +57,8 @@ pub async fn start_peer<A: ToSocketAddrs, C: 'static + NtpClock + Send>(
                         .reset(Instant::now() + poll_interval_to_duration(poll_interval));
 
                     // TODO: Figure out proper error behaviour here
-                    let packet = peer.generate_poll_message(clock.now().unwrap());
+                    let ntp_instant = NtpInstant::from_ntp_timestamp(clock.now().unwrap());
+                    let packet = peer.generate_poll_message(ntp_instant);
                     socket.send(&packet.serialize()).await.unwrap();
                 },
                 result = socket.recv(&mut buf) => {
@@ -70,11 +72,13 @@ pub async fn start_peer<A: ToSocketAddrs, C: 'static + NtpClock + Send>(
                         } else {
                             let packet = NtpHeader::deserialize(&buf);
 
+                            let ntp_instant = NtpInstant::from_ntp_timestamp(timestamp);
+
                             let system_snapshot = *system_snapshots.borrow_and_update();
-                            let result = peer.handle_incoming(packet, timestamp, system_snapshot);
+                            let result = peer.handle_incoming(system_snapshot, packet, ntp_instant, timestamp);
 
                             let system_poll = NtpDuration::from_exponent(system_snapshot.poll_interval);
-                            if peer.accept_synchronization(timestamp, system_poll).is_err() {
+                            if peer.accept_synchronization(ntp_instant, system_poll).is_err() {
                                 let _ = tx.send(None);
                             } else if let Ok(update) = result {
                                 let _ = tx.send(Some(update));

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -1,5 +1,6 @@
 use crate::peer::{PeerSnapshot, MAX_DISTANCE};
-use crate::{NtpDuration, NtpTimestamp};
+use crate::time_types::NtpInstant;
+use crate::NtpDuration;
 
 // TODO this should be 4 in production?!
 /// Minimum number of survivors needed to be able to discipline the system clock.
@@ -24,7 +25,7 @@ const MIN_CLUSTER_SURVIVORS: usize = 3;
 
 pub fn filter_and_combine(
     peers: &[PeerSnapshot],
-    local_clock_time: NtpTimestamp,
+    local_clock_time: NtpInstant,
     system_poll: NtpDuration,
 ) -> Option<ClockCombine> {
     let selection = clock_select(peers, local_clock_time, system_poll)?;
@@ -45,7 +46,7 @@ struct ClockSelect<'a> {
 
 fn clock_select(
     peers: &[PeerSnapshot],
-    local_clock_time: NtpTimestamp,
+    local_clock_time: NtpInstant,
     system_poll: NtpDuration,
 ) -> Option<ClockSelect> {
     let valid_associations = peers.iter().filter(|p| {
@@ -88,7 +89,7 @@ struct CandidateTuple<'a> {
 
 fn construct_candidate_list<'a>(
     valid_associations: impl IntoIterator<Item = &'a PeerSnapshot>,
-    local_clock_time: NtpTimestamp,
+    local_clock_time: NtpInstant,
 ) -> Vec<CandidateTuple<'a>> {
     let mut candidate_list = Vec::new();
 
@@ -131,7 +132,7 @@ struct SurvivorTuple<'a> {
 /// Collect the candidates within the correctness interval
 fn construct_survivors<'a>(
     chime_list: &[CandidateTuple<'a>],
-    local_clock_time: NtpTimestamp,
+    local_clock_time: NtpInstant,
 ) -> Vec<SurvivorTuple<'a>> {
     match find_interval(chime_list) {
         Some((low, high)) => chime_list
@@ -144,7 +145,7 @@ fn construct_survivors<'a>(
 
 fn filter_survivor<'a>(
     candidate: &CandidateTuple<'a>,
-    local_clock_time: NtpTimestamp,
+    local_clock_time: NtpInstant,
     low: NtpDuration,
     high: NtpDuration,
 ) -> Option<SurvivorTuple<'a>> {
@@ -318,8 +319,8 @@ pub struct ClockCombine {
 /// in particular they are in the order produced by the clustering algorithm.
 fn clock_combine<'a>(
     survivors: &'a [SurvivorTuple<'a>],
-    system_selection_jitter: NtpDuration, //
-    local_clock_time: NtpTimestamp,
+    system_selection_jitter: NtpDuration,
+    local_clock_time: NtpInstant,
 ) -> ClockCombine {
     let mut y = 0.0; // normalization factor
     let mut z = 0.0; // weighed offset sum
@@ -376,7 +377,7 @@ pub fn fuzz_find_interval(spec: &[(i64, u64)]) {
         });
     }
     candidates.sort_by(|a, b| a.edge.cmp(&b.edge));
-    let survivors = construct_survivors(&candidates, NtpTimestamp::from_fixed_int(0));
+    let survivors = construct_survivors(&candidates, crate::NtpTimestamp::ZERO);
 
     // check that if we find a cluster, it contains more than half of the peers we work with.
     assert!(survivors.is_empty() || 2 * survivors.len() > spec.len());
@@ -403,7 +404,7 @@ fn peer_snapshot(
         + statistics.dispersion;
 
     PeerSnapshot {
-        time: NtpTimestamp::from_fixed_int(0),
+        time: NtpInstant::ZERO,
         statistics,
         stratum: 0,
         root_distance_without_time,
@@ -468,7 +469,7 @@ mod test {
         let result = clock_combine(
             &survivors,
             NtpDuration::from_seconds(0.05),
-            NtpTimestamp::from_fixed_int(0),
+            NtpInstant::ZERO,
         );
         assert_eq!(result.system_offset, NtpDuration::from_fixed_int(0));
         assert!(result.system_jitter.to_seconds() >= 0.05);
@@ -527,7 +528,7 @@ mod test {
         let result = clock_combine(
             &survivors,
             NtpDuration::from_seconds(0.05),
-            NtpTimestamp::from_fixed_int(0),
+            NtpInstant::ZERO,
         );
         assert!(result.system_offset < NtpDuration::from_fixed_int(0));
         assert!(result.system_offset > NtpDuration::from_fixed_int(-500000));
@@ -596,7 +597,7 @@ mod test {
             ))
         );
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 3);
     }
 
@@ -662,7 +663,7 @@ mod test {
             ))
         );
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 2);
     }
 
@@ -730,7 +731,7 @@ mod test {
             ))
         );
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 3);
     }
 
@@ -798,7 +799,7 @@ mod test {
             ))
         );
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 3);
     }
 
@@ -859,7 +860,7 @@ mod test {
 
         assert_eq!(find_interval(&intervals), None);
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 0);
     }
 
@@ -921,7 +922,7 @@ mod test {
 
         assert_eq!(find_interval(&intervals), None);
 
-        let survivors = construct_survivors(&intervals, NtpTimestamp::from_fixed_int(0));
+        let survivors = construct_survivors(&intervals, NtpInstant::ZERO);
         assert_eq!(survivors.len(), 0);
     }
 
@@ -949,7 +950,7 @@ mod test {
             root_dispersion,
         );
 
-        let local_clock_time = NtpTimestamp::ZERO;
+        let local_clock_time = NtpInstant::ZERO;
         let actual: Vec<_> = construct_candidate_list([&peer1, &peer2], local_clock_time)
             .into_iter()
             .map(|t| (t.endpoint_type, t.edge))

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -377,7 +377,7 @@ pub fn fuzz_find_interval(spec: &[(i64, u64)]) {
         });
     }
     candidates.sort_by(|a, b| a.edge.cmp(&b.edge));
-    let survivors = construct_survivors(&candidates, crate::NtpTimestamp::ZERO);
+    let survivors = construct_survivors(&candidates, crate::NtpInstant::ZERO);
 
     // check that if we find a cluster, it contains more than half of the peers we work with.
     assert!(survivors.is_empty() || 2 * survivors.len() > spec.len());

--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -9,6 +9,7 @@
 
 use crate::packet::NtpAssociationMode;
 use crate::peer::{multiply_by_phi, PeerStatistics};
+use crate::time_types::NtpInstant;
 use crate::{packet::NtpLeapIndicator, NtpDuration, NtpHeader, NtpTimestamp};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -16,7 +17,7 @@ pub struct FilterTuple {
     offset: NtpDuration,
     delay: NtpDuration,
     dispersion: NtpDuration,
-    time: NtpTimestamp,
+    time: NtpInstant,
 }
 
 impl FilterTuple {
@@ -24,7 +25,7 @@ impl FilterTuple {
         offset: NtpDuration::ZERO,
         delay: NtpDuration::MAX_DISPERSION,
         dispersion: NtpDuration::MAX_DISPERSION,
-        time: NtpTimestamp::ZERO,
+        time: NtpInstant::ZERO,
     };
 
     fn is_dummy(self) -> bool {
@@ -38,8 +39,8 @@ impl FilterTuple {
     pub(crate) fn from_packet_default(
         packet: &NtpHeader,
         system_precision: NtpDuration,
+        local_clock_time: NtpInstant,
         destination_timestamp: NtpTimestamp,
-        local_clock_time: NtpTimestamp,
     ) -> Self {
         // for reference
         //
@@ -111,10 +112,10 @@ impl LastMeasurements {
     pub(crate) fn step(
         &mut self,
         new_tuple: FilterTuple,
-        peer_time: NtpTimestamp,
+        peer_time: NtpInstant,
         system_leap_indicator: NtpLeapIndicator,
         system_precision: NtpDuration,
-    ) -> Option<(PeerStatistics, NtpTimestamp)> {
+    ) -> Option<(PeerStatistics, NtpInstant)> {
         let dispersion_correction = multiply_by_phi(new_tuple.time - peer_time);
         self.shift_and_insert(new_tuple, dispersion_correction);
 
@@ -124,7 +125,9 @@ impl LastMeasurements {
         // Prime directive: use a sample only once and never a sample
         // older than the latest one, but anything goes before first
         // synchronized.
-        if smallest_delay.time <= peer_time && system_leap_indicator.is_synchronized() {
+        if (smallest_delay.time - peer_time) <= NtpDuration::ZERO
+            && system_leap_indicator.is_synchronized()
+        {
             return None;
         }
 
@@ -338,7 +341,7 @@ mod test {
 
         let mut measurements = LastMeasurements::default();
 
-        let peer_time = NtpTimestamp::default();
+        let peer_time = NtpInstant::ZERO;
         let update = measurements.step(
             new_tuple,
             peer_time,
@@ -357,12 +360,12 @@ mod test {
             offset: NtpDuration::from_seconds(12.0),
             delay: NtpDuration::from_seconds(14.0),
             dispersion: Default::default(),
-            time: NtpTimestamp::from_bits((1i64 << 32).to_be_bytes()),
+            time: NtpInstant::from_bits((1i64 << 32).to_be_bytes()),
         };
 
         let mut measurements = LastMeasurements::default();
 
-        let peer_time = NtpTimestamp::default();
+        let peer_time = NtpInstant::ZERO;
         let update = measurements.step(
             new_tuple,
             peer_time,
@@ -398,8 +401,8 @@ mod test {
         let result = FilterTuple::from_packet_default(
             &packet,
             NtpDuration::from_exponent(-32),
+            NtpInstant::from_fixed_int(4),
             NtpTimestamp::from_fixed_int(3),
-            NtpTimestamp::from_fixed_int(4),
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(0));
         assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
@@ -413,8 +416,8 @@ mod test {
         let result = FilterTuple::from_packet_default(
             &packet,
             NtpDuration::from_exponent(-32),
+            NtpInstant::from_fixed_int(4),
             NtpTimestamp::from_fixed_int(3),
-            NtpTimestamp::from_fixed_int(4),
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
         assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
@@ -428,8 +431,8 @@ mod test {
         let result = FilterTuple::from_packet_default(
             &packet,
             NtpDuration::from_exponent(-32),
+            NtpInstant::from_fixed_int(4),
             NtpTimestamp::from_fixed_int(3),
-            NtpTimestamp::from_fixed_int(4),
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
         assert_eq!(result.delay, NtpDuration::from_fixed_int(1));

--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -125,9 +125,7 @@ impl LastMeasurements {
         // Prime directive: use a sample only once and never a sample
         // older than the latest one, but anything goes before first
         // synchronized.
-        if (smallest_delay.time - peer_time) <= NtpDuration::ZERO
-            && system_leap_indicator.is_synchronized()
-        {
+        if smallest_delay.time <= peer_time && system_leap_indicator.is_synchronized() {
             return None;
         }
 

--- a/ntp-proto/src/filter.rs
+++ b/ntp-proto/src/filter.rs
@@ -264,8 +264,8 @@ pub fn fuzz_tuple_from_packet_default(
     let result = FilterTuple::from_packet_default(
         &packet,
         NtpDuration::from_exponent(client_precision),
+        NtpInstant::ZERO,
         NtpTimestamp::from_fixed_int(client.wrapping_add(client_interval as u64)),
-        NtpTimestamp::ZERO,
     );
 
     assert!(result.delay >= NtpDuration::from_fixed_int(0));

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -19,4 +19,4 @@ pub use packet::NtpHeader;
 pub use peer::{AcceptSynchronizationError, IgnoreReason, Peer, PeerSnapshot, SystemSnapshot};
 #[cfg(feature = "fuzz")]
 pub use time_types::fuzz_duration_from_seconds;
-pub use time_types::{NtpDuration, NtpTimestamp};
+pub use time_types::{NtpDuration, NtpInstant, NtpTimestamp};

--- a/ntp-proto/src/packet.rs
+++ b/ntp-proto/src/packet.rs
@@ -94,8 +94,11 @@ pub struct NtpHeader {
     pub root_dispersion: NtpDuration,
     pub reference_id: ReferenceId,
     pub reference_timestamp: NtpTimestamp,
+    /// Time at the client when the request departed for the server
     pub origin_timestamp: NtpTimestamp,
+    /// Time at the server when the request arrived from the client
     pub receive_timestamp: NtpTimestamp,
+    /// Time at the server when the response left for the client
     pub transmit_timestamp: NtpTimestamp,
 }
 

--- a/ntp-proto/src/time_types.rs
+++ b/ntp-proto/src/time_types.rs
@@ -1,5 +1,49 @@
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
+/// NtpInstant is a monotonically increasing value modelling the uptime of the NTP service
+///
+/// It is used to validate packets that we send out, and to order internal operations.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Default)]
+pub struct NtpInstant {
+    timestamp: NtpTimestamp,
+}
+
+impl NtpInstant {
+    pub const ZERO: Self = Self {
+        timestamp: NtpTimestamp::ZERO,
+    };
+
+    pub const fn from_ntp_timestamp(timestamp: NtpTimestamp) -> Self {
+        Self { timestamp }
+    }
+
+    #[cfg(any(test, feature = "fuzz"))]
+    pub(crate) const fn from_bits(bits: [u8; 8]) -> Self {
+        Self {
+            timestamp: NtpTimestamp::from_bits(bits),
+        }
+    }
+
+    pub(crate) const fn to_bits(self) -> [u8; 8] {
+        self.timestamp.to_bits()
+    }
+
+    #[cfg(any(test, feature = "fuzz"))]
+    pub(crate) const fn from_fixed_int(timestamp: u64) -> NtpInstant {
+        Self {
+            timestamp: NtpTimestamp::from_fixed_int(timestamp),
+        }
+    }
+}
+
+impl Sub for NtpInstant {
+    type Output = NtpDuration;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.timestamp - rhs.timestamp
+    }
+}
+
 /// NtpTimestamp represents an ntp timestamp without the era number.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Default)]
 pub struct NtpTimestamp {


### PR DESCRIPTION
While reading through the spec, we figured out that there are actually two clock domains. This isn't very explicit, certainly not expressed in the types, but probably important.

This PR at least makes the distinction on a type level. The new `NtpInstant` (name up for debate) is distinct from `NtpTimestamp`. `NtpTimestamp` is the type for time values that we actually get from a clock, when sending or receiving packages. \

The new `NtpInstant` is supposed to be a monotonically increasing value. In the spec it is roughly the uptime of the server, but only with 1-second increments. It is used to put bogus values into a packet (so verify that they are, or are not, updated), and to counter against replays. So far it seems that any monotonically increasing number will do, so the internal representation for now is still just a `NtpTimestamp`. 

It could be though that when we start messing with the clock, using timestamps based on that clock is not actually monotonic and that could cause issues. The NTP spec suggests that this number is incremented every second, but that means we need to have a tokio task that waits 1 second, and I'm not sure how that works if you change the system clock.