### PR TITLE
Peer reset infrastructure

### DIFF
--- a/ntp-daemon/src/main.rs
+++ b/ntp-daemon/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .iter_mut()
                 .enumerate()
                 .map(|(i, c)| async move {
-                    c.changed().await.unwrap();
+                    c.peer_snapshot.changed().await.unwrap();
                     i
                 })
                 .collect();
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             changed.next().await.unwrap()
         };
 
-        let msg = *peers[changed_index].borrow();
+        let msg = *peers[changed_index].peer_snapshot.borrow();
         match msg {
             peer::MsgForSystem::MustDemobilize => {
                 peers.remove(changed_index);
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         snapshots.clear();
 
         for i in (0..peers.len()).rev() {
-            let msg = *peers[i].borrow_and_update();
+            let msg = *peers[i].peer_snapshot.borrow_and_update();
             match msg {
                 peer::MsgForSystem::MustDemobilize => {
                     peers.remove(i);

--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -84,9 +84,9 @@ pub async fn start_peer<A: ToSocketAddrs, C: 'static + NtpClock + Send>(
                         // in-flight requests are ignored
                         peer.reset_measurements();
 
-                        // TODO: notify the system that the reset has been successful, and that this
+                        // notify the system that the reset has been successful, and that this
                         // association can produce valid measurements again
-                        // reset_for_system.notify_waiters();
+                        notify_reset_send.notify_waiters();
                     }
                 }
                 result = socket.recv(&mut buf) => {

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -377,6 +377,16 @@ impl Peer {
         Ok(())
     }
 
+    /// reset just the measurement data, the poll and connection data is unchanged
+    pub fn reset_measurements(&mut self) {
+        self.statistics = Default::default();
+        self.last_measurements = Default::default();
+        self.last_packet = Default::default();
+
+        // make sure in-flight messages are ignored
+        self.next_expected_origin = None;
+    }
+
     #[cfg(any(test, feature = "fuzz"))]
     pub(crate) fn test_peer() -> Self {
         Peer {

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -21,13 +21,14 @@ pub struct Peer {
     // Poll interval state
     last_poll_interval: PollInterval,
     next_poll_interval: PollInterval,
+    /// The poll interval desired by the remove server.
+    // Must be increased when the server sends the RATE kiss code.
     remote_min_poll_interval: PollInterval,
 
     // Last packet information
     /// We expect the next packet we receive to have this origin timestamp
-    ///
-    /// This is used as validation that the packet we get is the correct response to the one we sent
-    /// (guards against e.g. replay and packet reordering)
+    // This is used as validation that the packet we get is the correct response to the one we sent
+    // (guards against e.g. replay and packet reordering)
     next_expected_origin: Option<NtpTimestamp>,
 
     statistics: PeerStatistics,
@@ -185,6 +186,9 @@ impl Peer {
             .max(self.remote_min_poll_interval)
             .max(self.next_poll_interval);
 
+        // by default, we set the next poll interval to be an order of magnitude higher than the
+        // current one (in base 2). If we get a successful response, we set the interval back to
+        // the `last_poll_interval` (which means effectively the poll inteval is constant)
         self.next_poll_interval = self.last_poll_interval.inc();
 
         self.last_poll_interval
@@ -246,7 +250,9 @@ impl Peer {
             // For reachability, mark that we have had a response
             self.reach.received_packet();
 
-            // Received answer, so no need for backoff
+            // By default, next_poll_interval is an order of magnitude higher than
+            // last_poll_interval, so we automatically back off if we get no response.
+            // Here we did get a response, so we can keep the poll interval constant
             self.next_poll_interval = self.last_poll_interval;
 
             // we received this packet, and don't want to accept future ones with this next_expected_origin

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -24,6 +24,10 @@ pub struct Peer {
     remote_min_poll_interval: PollInterval,
 
     // Last packet information
+    /// We expect the next packet we receive to have this origin timestamp
+    ///
+    /// This is used as validation that the packet we get is the correct response to the one we sent
+    /// (guards against e.g. replay and packet reordering)
     next_expected_origin: Option<NtpTimestamp>,
 
     statistics: PeerStatistics,
@@ -215,6 +219,9 @@ impl Peer {
         frequency_tolerance: FrequencyTolerance,
         recv_time: NtpTimestamp,
     ) -> Result<PeerSnapshot, IgnoreReason> {
+        // we're expecting a packet
+        debug_assert!(self.next_expected_origin.is_some());
+
         // the transmit_timestamp field was not changed from the bogus value we put into it
         let transmit_unchanged = Some(message.transmit_timestamp) == self.next_expected_origin;
 
@@ -241,6 +248,9 @@ impl Peer {
 
             // Received answer, so no need for backoff
             self.next_poll_interval = self.last_poll_interval;
+
+            // we received this packet, and don't want to accept future ones with this next_expected_origin
+            self.next_expected_origin = None;
 
             let filter_input = FilterTuple::from_packet_default(
                 &message,


### PR DESCRIPTION
sets up the communication channels and logic for the reset of all peers. It does not yet have logic for triggering a reset, because that depends on the clock adjustment 