### PR TITLE
Fixed peer timestamp logic during packet handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,7 +239,7 @@ dependencies = [
  "log",
  "miow",
  "ntapi",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -277,6 +288,7 @@ name = "ntp-proto"
 version = "0.1.0"
 dependencies = [
  "md-5",
+ "rand",
 ]
 
 [[package]]
@@ -341,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +374,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -565,6 +613,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -77,8 +77,7 @@ pub async fn start_peer<A: ToSocketAddrs + std::fmt::Debug, C: 'static + NtpCloc
                         .as_mut()
                         .reset(Instant::now() + poll_interval.as_system_duration());
 
-                    let ntp_instant = NtpInstant::now();
-                    let packet = peer.generate_poll_message(ntp_instant);
+                    let packet = peer.generate_poll_message();
 
                     match clock.now() {
                         Err(e) => {

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -11,3 +11,4 @@ fuzz = []
 
 [dependencies]
 md-5 = "0.10.1"
+rand = "0.8.5"

--- a/ntp-proto/src/identifiers.rs
+++ b/ntp-proto/src/identifiers.rs
@@ -7,9 +7,9 @@ pub struct ReferenceId(u32);
 
 impl ReferenceId {
     // Note: Names chosen to match the identifiers given in rfc5905
-    const KISS_DENY: u32 = 0x44454E59;
-    const KISS_RATE: u32 = 0x52415445;
-    const KISS_RSTR: u32 = 0x52535452;
+    pub(crate) const KISS_DENY: ReferenceId = ReferenceId(0x44454E59);
+    pub(crate) const KISS_RATE: ReferenceId = ReferenceId(0x52415445);
+    pub(crate) const KISS_RSTR: ReferenceId = ReferenceId(0x52535452);
 
     pub fn from_ip(addr: IpAddr) -> ReferenceId {
         match addr {
@@ -25,15 +25,15 @@ impl ReferenceId {
     }
 
     pub(crate) fn is_deny(&self) -> bool {
-        self.0 == Self::KISS_DENY
+        *self == Self::KISS_DENY
     }
 
     pub(crate) fn is_rate(&self) -> bool {
-        self.0 == Self::KISS_RATE
+        *self == Self::KISS_RATE
     }
 
     pub(crate) fn is_rstr(&self) -> bool {
-        self.0 == Self::KISS_RSTR
+        *self == Self::KISS_RSTR
     }
 
     pub(crate) fn to_bytes(self) -> [u8; 4] {

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -4,6 +4,7 @@ use crate::{
     time_types::{FrequencyTolerance, NtpInstant},
     NtpDuration, NtpHeader, NtpTimestamp, PollInterval, ReferenceId,
 };
+use rand::{thread_rng, Rng};
 
 const MAX_STRATUM: u8 = 16;
 
@@ -198,23 +199,20 @@ impl Peer {
         self.last_poll_interval
     }
 
-    pub fn generate_poll_message(&mut self, local_clock_time: NtpInstant) -> NtpHeader {
+    pub fn generate_poll_message(&mut self) -> NtpHeader {
         self.reach.poll();
 
         let mut packet = NtpHeader::new();
         packet.poll = self.last_poll_interval.as_log();
         packet.mode = NtpAssociationMode::Client;
 
-        // we write into the origin_timestamp and transmit_timestamp to validate the packet we get
-        // back. The origin_timestamp must not be changed, the transmit_timestamp must be changed
-        let local_clock_time = NtpTimestamp::from_bits(local_clock_time.to_bits());
-        self.next_expected_origin = Some(local_clock_time);
-
-        // in handle_incoming, we check that this field is unchanged
-        packet.origin_timestamp = local_clock_time;
-
-        // in handle_incoming, we check that this field was updated
-        packet.transmit_timestamp = local_clock_time;
+        // In order to increase the entropy of the transmit timestamp
+        // it is just a randomly generated timestamp.
+        // We then expect to get it back identically from the remote
+        // in the origin field.
+        let transmit_timestamp = thread_rng().gen();
+        self.next_expected_origin = Some(transmit_timestamp);
+        packet.transmit_timestamp = transmit_timestamp;
 
         packet
     }
@@ -228,29 +226,25 @@ impl Peer {
         send_time: NtpTimestamp,
         recv_time: NtpTimestamp,
     ) -> Result<PeerSnapshot, IgnoreReason> {
-        // we're expecting a packet
-        debug_assert!(self.next_expected_origin.is_some());
-
-        // the transmit_timestamp field was not changed from the bogus value we put into it
-        let transmit_unchanged = Some(message.transmit_timestamp) == self.next_expected_origin;
-
-        // the origin_timestamp changed; the server is not allowed to modify this field
-        let origin_changed = Some(message.origin_timestamp) != self.next_expected_origin;
-
         if message.mode != NtpAssociationMode::Server {
             // we currently only support a client <-> server association
             Err(IgnoreReason::InvalidMode)
-        } else if transmit_unchanged || origin_changed {
-            Err(IgnoreReason::InvalidPacketTime)
         } else if message.is_kiss_rate() {
+            // KISS packets may not have correct timestamps at all, handle them anyway
             self.remote_min_poll_interval =
                 Ord::max(self.remote_min_poll_interval.inc(), self.last_poll_interval);
             Err(IgnoreReason::KissIgnore)
         } else if message.is_kiss_rstr() || message.is_kiss_deny() {
+            // KISS packets may not have correct timestamps at all, handle them anyway
             Err(IgnoreReason::KissDemobilize)
         } else if message.is_kiss() {
             // Ignore unrecognized control messages
             Err(IgnoreReason::KissIgnore)
+        } else if Some(message.origin_timestamp) != self.next_expected_origin {
+            // Packets should be a response to a previous request from us,
+            // if not just ignore. Note that this might also happen when
+            // we reset between sending the request and receiving the response.s
+            Err(IgnoreReason::InvalidPacketTime)
         } else {
             // For reachability, mark that we have had a response
             self.reach.received_packet();


### PR DESCRIPTION
Note that due to the nature of the problem this does slightly more than just fix the issue.