### PR TITLE
Initial configuration setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +132,45 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "core-foundation"
@@ -357,6 +407,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -622,13 +678,17 @@ dependencies = [
 name = "ntp-daemon"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "futures",
  "ntp-os-clock",
  "ntp-proto",
  "ntp-udp",
  "sentry",
  "sentry-tracing",
+ "serde",
+ "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -648,6 +708,7 @@ version = "0.1.0"
 dependencies = [
  "md-5",
  "rand",
+ "serde",
  "tracing",
 ]
 
@@ -742,6 +803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +860,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1163,6 +1254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-binaries"
 version = "0.1.0"
 dependencies = [
@@ -1200,6 +1306,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1336,6 +1448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1516,7 @@ dependencies = [
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1599,6 +1721,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/ntp-daemon/Cargo.toml
+++ b/ntp-daemon/Cargo.toml
@@ -13,7 +13,11 @@ ntp-proto = { path = "../ntp-proto" }
 ntp-os-clock = { path = "../ntp-os-clock" }
 ntp-udp = { path = "../ntp-udp" }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "serde"] }
+clap = { version = "3.1.18", features = ["derive", "env"] }
+toml = "0.5.9"
+thiserror = "1.0.31"
+serde = { version = "1.0.137", features = ["derive"] }
 sentry = { version = "0.26.0", optional = true }
 sentry-tracing = { version = "0.26.0", optional = true }
 

--- a/ntp-daemon/src/config/mod.rs
+++ b/ntp-daemon/src/config/mod.rs
@@ -1,0 +1,110 @@
+mod peer;
+
+pub use peer::*;
+
+use clap::Parser;
+use ntp_proto::SystemConfig;
+use serde::{de, Deserialize, Deserializer};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+use tokio::{fs::read_to_string, io};
+use tracing::info;
+use tracing_subscriber::filter::{self, EnvFilter};
+
+fn parse_env_filter(input: &str) -> Result<EnvFilter, filter::ParseError> {
+    EnvFilter::builder().with_regex(false).parse(input)
+}
+
+fn deserialize_option_env_filter<'de, D>(deserializer: D) -> Result<Option<EnvFilter>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let data: Option<&str> = Deserialize::deserialize(deserializer)?;
+    if let Some(dirs) = data {
+        // allow us to recognise configs with an empty log filter directive
+        if dirs.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(EnvFilter::try_new(dirs).map_err(de::Error::custom)?))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct CmdArgs {
+    #[clap(short, long = "peer", global = true, value_name = "SERVER")]
+    pub peers: Vec<PeerConfig>,
+
+    #[clap(short, long, parse(from_os_str), global = true, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
+    #[clap(long, short, global = true, parse(try_from_str = parse_env_filter), env = "NTP_LOG")]
+    pub log_filter: Option<EnvFilter>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub struct Config {
+    #[serde(deserialize_with = "deserialize_peer_configs")]
+    pub peers: Vec<PeerConfig>,
+    pub system: SystemConfig,
+    #[serde(deserialize_with = "deserialize_option_env_filter")]
+    pub log_filter: Option<EnvFilter>,
+}
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("io error while reading config: {0}")]
+    Io(#[from] io::Error),
+    #[error("config toml parsing error: {0}")]
+    Toml(#[from] toml::de::Error),
+}
+
+impl Config {
+    async fn from_file(file: impl AsRef<Path>) -> Result<Config, ConfigError> {
+        let contents = read_to_string(file).await?;
+        Ok(toml::de::from_str(&contents)?)
+    }
+
+    async fn from_first_file(file: Option<impl AsRef<Path>>) -> Result<Config, ConfigError> {
+        // if an explicit file is given, always use that one
+        if let Some(f) = file {
+            return Config::from_file(f).await;
+        }
+
+        // try ntp.toml in working directory or skip if file doesn't exist
+        match Config::from_file("./ntp.toml").await {
+            Err(ConfigError::Io(e)) if e.kind() == ErrorKind::NotFound => {}
+            other => return other,
+        }
+
+        // for the global file we also ignore it when there are permission errors
+        match Config::from_file("/etc/ntp.toml").await {
+            Err(ConfigError::Io(e))
+                if e.kind() == ErrorKind::NotFound || e.kind() == ErrorKind::PermissionDenied => {}
+            other => return other,
+        }
+
+        Ok(Config::default())
+    }
+
+    pub async fn from_args(
+        file: Option<impl AsRef<Path>>,
+        peers: Vec<PeerConfig>,
+    ) -> Result<Config, ConfigError> {
+        let mut config = Config::from_first_file(file).await?;
+
+        if !peers.is_empty() {
+            if !config.peers.is_empty() {
+                info!("overriding peers from configuration");
+            }
+            config.peers = peers;
+        }
+
+        Ok(config)
+    }
+}

--- a/ntp-daemon/src/config/peer.rs
+++ b/ntp-daemon/src/config/peer.rs
@@ -1,0 +1,98 @@
+use std::{convert::Infallible, fmt, net::SocketAddr, str::FromStr};
+
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+#[derive(Deserialize, Debug)]
+pub enum PeerHostMode {
+    Server,
+}
+
+impl Default for PeerHostMode {
+    fn default() -> Self {
+        PeerHostMode::Server
+    }
+}
+
+fn deserialize_peer_addr<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let data = Deserialize::deserialize(deserializer)?;
+    Ok(fix_addr(data))
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PeerConfig {
+    #[serde(deserialize_with = "deserialize_peer_addr")]
+    pub addr: String,
+    pub mode: PeerHostMode,
+}
+
+impl PeerConfig {
+    pub fn new(host: &str) -> PeerConfig {
+        PeerConfig {
+            addr: fix_addr(host.to_owned()),
+            mode: PeerHostMode::Server,
+        }
+    }
+}
+
+/// Adds :123 to peer address if it is missing
+fn fix_addr(mut addr: String) -> String {
+    if addr.parse::<SocketAddr>().is_ok() {
+        return addr;
+    }
+
+    addr.push_str(":123");
+    addr
+}
+
+impl FromStr for PeerConfig {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: We could do some sanity checks here to fail a bit earlier
+        Ok(PeerConfig::new(s))
+    }
+}
+
+/// Deserializes a peer configuration from either a string or a map
+pub(crate) fn deserialize_peer_config<'de, D>(deserializer: D) -> Result<PeerConfig, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct PeerConfigVisitor;
+
+    impl<'de> Visitor<'de> for PeerConfigVisitor {
+        type Value = PeerConfig;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<PeerConfig, E> {
+            FromStr::from_str(value).map_err(de::Error::custom)
+        }
+
+        fn visit_map<M: MapAccess<'de>>(self, map: M) -> Result<PeerConfig, M::Error> {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(PeerConfigVisitor)
+}
+
+/// Deserializes a vec of peerconfigs from a list of strings/maps
+pub(crate) fn deserialize_peer_configs<'de, D>(deserializer: D) -> Result<Vec<PeerConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Wrapper(#[serde(deserialize_with = "deserialize_peer_config")] PeerConfig);
+
+    let v = Vec::deserialize(deserializer)?;
+    Ok(v.into_iter().map(|Wrapper(config)| config).collect())
+}

--- a/ntp-daemon/src/lib.rs
+++ b/ntp-daemon/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
+pub mod config;
 mod peer;
 mod system;
+pub mod tracing;
 
 pub use system::spawn;

--- a/ntp-daemon/src/tracing.rs
+++ b/ntp-daemon/src/tracing.rs
@@ -1,0 +1,52 @@
+use tracing::Subscriber;
+use tracing_subscriber::{reload, EnvFilter, Registry};
+
+type FormatLayer<S> =
+    tracing_subscriber::filter::Filtered<tracing_subscriber::fmt::Layer<S>, EnvFilter, S>;
+type TracingFilterHandle = reload::Handle<FormatLayer<Registry>, Registry>;
+
+fn init_fmt_layer<S>(
+    filter: EnvFilter,
+) -> (
+    reload::Layer<FormatLayer<S>, S>,
+    reload::Handle<FormatLayer<S>, S>,
+)
+where
+    S: Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    use tracing_subscriber::prelude::*;
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_filter(filter);
+    tracing_subscriber::reload::Layer::new(fmt_layer)
+}
+
+#[cfg(feature = "sentry")]
+pub fn init(filter: EnvFilter) -> (sentry::ClientInitGuard, TracingFilterHandle) {
+    use tracing_subscriber::prelude::*;
+
+    let guard = sentry::init(sentry::ClientOptions {
+        // Set this a to lower value in production
+        traces_sample_rate: 1.0,
+        ..sentry::ClientOptions::default()
+    });
+
+    let (fmt_layer, reload_handle) = init_fmt_layer(filter);
+
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(sentry_tracing::layer())
+        .init();
+
+    (guard, reload_handle)
+}
+
+#[cfg(not(feature = "sentry"))]
+pub fn init(filter: EnvFilter) -> ((), TracingFilterHandle) {
+    use tracing_subscriber::prelude::*;
+
+    let (fmt_layer, reload_handle) = init_fmt_layer(filter);
+
+    tracing_subscriber::registry().with(fmt_layer).init();
+
+    ((), reload_handle)
+}

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -13,3 +13,4 @@ fuzz = []
 md-5 = "0.10.1"
 rand = "0.8.5"
 tracing = "0.1.34"
+serde = { version = "1.0.137", features = ["derive"] }

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -1,9 +1,10 @@
 use crate::peer::PeerSnapshot;
 use crate::time_types::{FrequencyTolerance, NtpInstant};
 use crate::{NtpDuration, PollInterval};
+use serde::Deserialize;
 use tracing::{debug, instrument, trace, warn};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone, Copy)]
 pub struct SystemConfig {
     /// Minimum number of survivors needed to be able to discipline the system clock.
     /// More survivors (so more servers from which to get the time) means a more accurate time.
@@ -13,6 +14,7 @@ pub struct SystemConfig {
     /// > CMIN defines the minimum number of servers consistent with the correctness requirements.
     /// > Suspicious operators would set CMIN to ensure multiple redundant servers are available for the
     /// > algorithms to mitigate properly. However, for historic reasons the default value for CMIN is one.
+    #[serde(default = "default_min_intersection_survivors")]
     pub min_intersection_survivors: usize,
 
     /// Number of survivors that the cluster_algorithm tries to keep.
@@ -23,14 +25,17 @@ pub struct SystemConfig {
     ///
     /// Because the input can have fewer than 3 survivors, the MIN_CLUSTER_SURVIVORS
     /// is not an actual lower bound on the number of survivors.
+    #[serde(default = "default_min_cluster_survivors")]
     pub min_cluster_survivors: usize,
 
     /// How much the time is allowed to drift (worst-case) per second.
     /// The drift caused by our frequency not exactly matching the real time
+    #[serde(default = "default_frequency_tolerance")]
     pub frequency_tolerance: FrequencyTolerance,
 
     /// A distance error occurs if the root distance exceeds the
     /// distance threshold plus an increment equal to one poll interval.
+    #[serde(default = "default_distance_threshold")]
     pub distance_threshold: NtpDuration,
 }
 
@@ -38,12 +43,28 @@ impl Default for SystemConfig {
     fn default() -> Self {
         Self {
             // TODO this should be 4 in production?!
-            min_intersection_survivors: 1,
-            min_cluster_survivors: 3,
-            frequency_tolerance: FrequencyTolerance::ppm(15),
-            distance_threshold: NtpDuration::ONE,
+            min_intersection_survivors: default_min_intersection_survivors(),
+            min_cluster_survivors: default_min_cluster_survivors(),
+            frequency_tolerance: default_frequency_tolerance(),
+            distance_threshold: default_distance_threshold(),
         }
     }
+}
+
+fn default_min_intersection_survivors() -> usize {
+    1
+}
+
+fn default_min_cluster_survivors() -> usize {
+    3
+}
+
+fn default_frequency_tolerance() -> FrequencyTolerance {
+    FrequencyTolerance::ppm(15)
+}
+
+fn default_distance_threshold() -> NtpDuration {
+    NtpDuration::ONE
 }
 
 #[derive(Debug, Clone)]

--- a/ntp-proto/src/time_types.rs
+++ b/ntp-proto/src/time_types.rs
@@ -2,6 +2,7 @@ use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
+use serde::Deserialize;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use std::time::{Duration, Instant};
 
@@ -320,6 +321,16 @@ impl NtpDuration {
     }
 }
 
+impl<'de> Deserialize<'de> for NtpDuration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let seconds: f64 = Deserialize::deserialize(deserializer)?;
+        Ok(NtpDuration::from_seconds(seconds))
+    }
+}
+
 impl Add for NtpDuration {
     type Output = NtpDuration;
 
@@ -507,6 +518,16 @@ impl Default for PollInterval {
 #[derive(Debug, Clone, Copy)]
 pub struct FrequencyTolerance {
     ppm: u32,
+}
+
+impl<'de> Deserialize<'de> for FrequencyTolerance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let val: u32 = Deserialize::deserialize(deserializer)?;
+        Ok(FrequencyTolerance { ppm: val })
+    }
 }
 
 impl FrequencyTolerance {

--- a/ntp.toml
+++ b/ntp.toml
@@ -1,0 +1,16 @@
+log_filter = "trace"
+
+peers = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
+
+# [[peers]]
+# addr = "0.pool.ntp.org:123"
+#
+
+# [[peers]]
+# addr = "1.pool.ntp.org:123"
+
+[system]
+min_intersection_survivors = 1
+min_cluster_survivors = 3
+frequency_tolerance = 15
+distance_threshold = 1

--- a/test-binaries/src/bin/client.rs
+++ b/test-binaries/src/bin/client.rs
@@ -1,3 +1,4 @@
+use ntp_daemon::config::PeerConfig;
 use ntp_proto::SystemConfig;
 use std::error::Error;
 
@@ -7,13 +8,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let config = SystemConfig::default();
 
-    let peer_addresses = [
-        // "0.pool.ntp.org:123",
-        // "1.pool.ntp.org:123",
-        // "2.pool.ntp.org:123",
-        // "3.pool.ntp.org:123",
-        "0.0.0.0:8080",
-    ];
+    let peers = [PeerConfig::new("0.0.0.0:8080")];
 
-    ntp_daemon::spawn(&config, &peer_addresses).await
+    ntp_daemon::spawn(&config, &peers).await
 }


### PR DESCRIPTION
This adds command line arguments and toml configuration parsing.

Some notes:

- A few options are available as command line arguments, mostly a way to specify the configuration file and an option to override the log filter. If a `NTP_LOG` environment variable is available, that is used as well for configuration the log filter.
- It is also possible to set the peers directly via the command line arguments, this will override the peers from the config.
- In the configuration each peer can be represented as a string or as a map. The map syntax can be used in the future for peer specific configuration (such as enabling initial burst mode, or defining peers with other discovery mechanisms).
- When we want the peerconfig to implement different discovery mechanisms we probably want to turn it into an enum instead.
- Currently we ignore unknown keys in the config, but I think we might add a flag to the serde deserialize config to disable that, as it may prevent typos etc
- Asside from peers we can currently also set the system configuration, but all values are currently just simple integers, I think for parsing of the `NtpDuration` for the distance threshold and `FrequencyTolerance` we may want to add a little more additional parsing in the future to make it a little easier to use for humans.