### PR TITLE
Move accept logic to system

### DIFF
--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -3,8 +3,8 @@ use std::{ops::ControlFlow, pin::Pin, sync::Arc};
 use tracing::warn;
 
 use ntp_proto::{
-    AcceptSynchronizationError, IgnoreReason, NtpClock, NtpHeader, NtpInstant, NtpTimestamp, Peer,
-    PeerSnapshot, PollInterval, ReferenceId, SystemConfig, SystemSnapshot,
+    IgnoreReason, NtpClock, NtpHeader, NtpInstant, NtpTimestamp, Peer, PeerSnapshot, ReferenceId,
+    SystemConfig, SystemSnapshot,
 };
 use ntp_udp::UdpSocket;
 use tracing::{info, instrument};
@@ -42,9 +42,6 @@ pub enum MsgForSystem {
     MustDemobilize(PeerIndex),
     /// Received an acceptable packet and made a new peer snapshot
     Snapshot(PeerIndex, ResetEpoch, PeerSnapshot),
-    /// Received a packet, but its content is not acceptable for synchronization
-    /// (e.g. invalid stratum, large root distance, forms a loop or peer is unreachable)
-    PeerNotFit(PeerIndex),
 }
 
 pub(crate) struct PeerChannels {
@@ -92,22 +89,7 @@ where
             .reset(self.last_poll_sent + poll_interval);
     }
 
-    fn fitness(
-        &self,
-        ntp_instant: NtpInstant,
-        system_poll: PollInterval,
-    ) -> Result<(), AcceptSynchronizationError> {
-        self.peer.accept_synchronization(
-            ntp_instant,
-            self.config.frequency_tolerance,
-            self.config.distance_threshold,
-            system_poll.as_duration(),
-        )
-    }
-
     async fn handle_poll(&mut self, poll_wait: &mut Pin<&mut Sleep>) {
-        let ntp_instant = NtpInstant::now();
-
         let system_snapshot = *self.channels.system_snapshots.read().await;
         let packet = self.peer.generate_poll_message(system_snapshot);
 
@@ -115,13 +97,7 @@ where
         self.last_poll_sent = Instant::now();
         self.update_poll_wait(poll_wait, system_snapshot);
 
-        let accept = self.fitness(ntp_instant, system_snapshot.poll_interval);
-
-        if let Err(accept_error) = accept {
-            info!(?accept_error, "peer is not fit for use in synchronization");
-            let msg = MsgForSystem::PeerNotFit(self.index);
-            self.channels.msg_for_system_sender.send(msg).await.ok();
-        }
+        // NOTE: fitness check is not performed here, but by System
 
         match self.clock.now() {
             Err(e) => {
@@ -164,14 +140,9 @@ where
             Ok(update) => {
                 info!("packet accepted");
 
-                let msg = match self.fitness(ntp_instant, system_snapshot.poll_interval) {
-                    Err(accept_error) => {
-                        info!(?accept_error, "peer is not fit for use in synchronization");
-                        MsgForSystem::PeerNotFit(self.index)
-                    }
-                    Ok(_) => MsgForSystem::Snapshot(self.index, self.reset_epoch, update),
-                };
+                // NOTE: fitness check is not performed here, but by System
 
+                let msg = MsgForSystem::Snapshot(self.index, self.reset_epoch, update);
                 self.channels.msg_for_system_sender.send(msg).await.ok();
             }
             Err(IgnoreReason::KissDemobilize) => {

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -583,6 +583,9 @@ fn peer_snapshot(
         + root_dispersion
         + statistics.dispersion;
 
+    let mut reach = crate::peer::Reach::default();
+    reach.received_packet();
+
     PeerSnapshot {
         time: instant,
         statistics,
@@ -592,8 +595,12 @@ fn peer_snapshot(
         peer_id: ReferenceId::from_int(0),
 
         leap_indicator: NtpLeapIndicator::NoWarning,
-        root_delay: root_delay,
-        root_dispersion: root_dispersion,
+        root_delay,
+        root_dispersion,
+
+        reference_id: ReferenceId::from_int(0),
+        our_id: ReferenceId::from_int(1),
+        reach,
     }
 }
 

--- a/ntp-proto/src/clock_select.rs
+++ b/ntp-proto/src/clock_select.rs
@@ -190,6 +190,8 @@ fn clock_select<'a>(
     system_poll: PollInterval,
 ) -> Option<ClockSelect<'a>> {
     let valid_associations = peers.iter().filter(|p| {
+        // only failure reason we should see here is the distance; system already checks for other
+        // causes and would not enter clock selection if the snapshot is not acceptable.
         p.accept_synchronization(
             local_clock_time,
             config.frequency_tolerance,

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -20,4 +20,4 @@ pub use packet::{NtpAssociationMode, NtpHeader, NtpLeapIndicator};
 pub use peer::{AcceptSynchronizationError, IgnoreReason, Peer, PeerSnapshot, SystemSnapshot};
 #[cfg(feature = "fuzz")]
 pub use time_types::fuzz_duration_from_seconds;
-pub use time_types::{NtpDuration, NtpInstant, NtpTimestamp, PollInterval};
+pub use time_types::{FrequencyTolerance, NtpDuration, NtpInstant, NtpTimestamp, PollInterval};

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -123,7 +123,7 @@ pub struct PeerSnapshot {
 }
 
 impl PeerSnapshot {
-    pub(crate) fn accept_synchronization(
+    pub fn accept_synchronization(
         &self,
         local_clock_time: NtpInstant,
         frequency_tolerance: FrequencyTolerance,
@@ -195,6 +195,22 @@ impl PeerSnapshot {
     ) -> NtpDuration {
         self.root_distance_without_time
             + (NtpInstant::abs_diff(local_clock_time, self.time) * frequency_tolerance)
+    }
+
+    fn from_peer(peer: &Peer) -> Self {
+        Self {
+            root_distance_without_time: peer.root_distance_without_time(),
+            statistics: peer.statistics,
+            time: peer.time,
+            stratum: peer.last_packet.stratum,
+            peer_id: peer.peer_id,
+            reference_id: peer.last_packet.reference_id,
+            our_id: peer.our_id,
+            reach: peer.reach,
+            leap_indicator: peer.last_packet.leap,
+            root_delay: peer.last_packet.root_delay,
+            root_dispersion: peer.last_packet.root_dispersion,
+        }
     }
 }
 
@@ -344,21 +360,7 @@ impl Peer {
                 self.statistics = statistics;
                 self.time = smallest_delay_time;
 
-                let snapshot = PeerSnapshot {
-                    root_distance_without_time: self.root_distance_without_time(),
-                    statistics: self.statistics,
-                    time: self.time,
-                    stratum: self.last_packet.stratum,
-                    peer_id: self.peer_id,
-                    reference_id: self.last_packet.reference_id,
-                    our_id: self.our_id,
-                    reach: self.reach,
-                    leap_indicator: self.last_packet.leap,
-                    root_delay: self.last_packet.root_delay,
-                    root_dispersion: self.last_packet.root_dispersion,
-                };
-
-                Ok(snapshot)
+                Ok(PeerSnapshot::from_peer(self))
             }
         }
     }
@@ -367,6 +369,7 @@ impl Peer {
     /// all causes of the local clock relative to the primary server.
     /// It is defined as half the total delay plus total dispersion
     /// plus peer jitter.
+    #[cfg(test)]
     fn root_distance(
         &self,
         local_clock_time: NtpInstant,
@@ -382,60 +385,6 @@ impl Peer {
             + self.last_packet.root_dispersion
             + self.statistics.dispersion
             + NtpDuration::from_seconds(self.statistics.jitter)
-    }
-
-    /// Test if association p is acceptable for synchronization
-    ///
-    /// Known as `accept` and `fit` in the specification.
-    #[instrument(skip(self), fields(peer = debug(self.peer_id)))]
-    pub fn accept_synchronization(
-        &self,
-        local_clock_time: NtpInstant,
-        frequency_tolerance: FrequencyTolerance,
-        distance_threshold: NtpDuration,
-        system_poll: NtpDuration,
-    ) -> Result<(), AcceptSynchronizationError> {
-        use AcceptSynchronizationError::*;
-
-        // A stratum error occurs if
-        //     1: the server has never been synchronized,
-        //     2: the server stratum is invalid
-        if !self.last_packet.leap.is_synchronized() || self.last_packet.stratum >= MAX_STRATUM {
-            warn!(
-                stratum = debug(self.last_packet.stratum),
-                "Peer rejected due to invalid stratum"
-            );
-            return Err(Stratum);
-        }
-
-        //  A distance error occurs if the root distance exceeds the
-        //  distance threshold plus an increment equal to one poll interval.
-        let distance = self.root_distance(local_clock_time, frequency_tolerance);
-        if distance > distance_threshold + (system_poll * frequency_tolerance) {
-            debug!(
-                distance = debug(distance),
-                limit = debug(distance_threshold + (system_poll * frequency_tolerance)),
-                "Peer rejected due to excessive distance"
-            );
-            return Err(Distance);
-        }
-
-        // Detect whether the remote uses us as their main time reference.
-        // if so, we shouldn't sync to them as that would create a loop.
-        // Note, this can only ever be an issue if the peer is not using
-        // hardware as its source, so ignore reference_id if stratum is 1.
-        if self.last_packet.stratum != 1 && self.last_packet.reference_id == self.our_id {
-            debug!("Peer rejected because of detected synchornization loop");
-            return Err(Loop);
-        }
-
-        // An unreachable error occurs if the server is unreachable.
-        if !self.reach.is_reachable() {
-            warn!("Peer unreachable");
-            return Err(ServerUnreachable);
-        }
-
-        Ok(())
     }
 
     /// reset just the measurement data, the poll and connection data is unchanged
@@ -622,50 +571,39 @@ mod test {
         let local_clock_time = NtpInstant::now();
         let ft = FrequencyTolerance::ppm(15);
         let dt = NtpDuration::ONE;
-        let system_poll = NtpDuration::ZERO;
+        let system_poll = PollInterval::MIN;
 
         let mut peer = Peer::test_peer(local_clock_time);
 
+        macro_rules! accept {
+            () => {{
+                let snapshot = PeerSnapshot::from_peer(&peer);
+                snapshot.accept_synchronization(local_clock_time, ft, dt, system_poll)
+            }};
+        }
+
         // by default, the packet id and the peer's id are the same, indicating a loop
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Err(Loop)
-        );
+        assert_eq!(accept!(), Err(Loop));
 
         peer.our_id = ReferenceId::from_int(42);
 
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Err(ServerUnreachable)
-        );
+        assert_eq!(accept!(), Err(ServerUnreachable));
 
         peer.reach.received_packet();
 
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Ok(())
-        );
+        assert_eq!(accept!(), Ok(()));
 
         peer.last_packet.leap = NtpLeapIndicator::Unknown;
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Err(Stratum)
-        );
+        assert_eq!(accept!(), Err(Stratum));
 
         peer.last_packet.leap = NtpLeapIndicator::NoWarning;
         peer.last_packet.stratum = 42;
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Err(Stratum)
-        );
+        assert_eq!(accept!(), Err(Stratum));
 
         peer.last_packet.stratum = 0;
 
         peer.last_packet.root_dispersion = dt * 2;
-        assert_eq!(
-            peer.accept_synchronization(local_clock_time, ft, dt, system_poll),
-            Err(Distance)
-        );
+        assert_eq!(accept!(), Err(Distance));
     }
 
     #[test]

--- a/ntp.toml
+++ b/ntp.toml
@@ -1,4 +1,4 @@
-log_filter = "trace"
+log_filter = "info"
 
 peers = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
 


### PR DESCRIPTION
when a peer has a snapshot, it will now always send it to the system. The system is now resonsible for doing the acceptance check.

The upside of this change is that the system has a more complete picture of what the peers are doing. This is nice for observability.