### PR TITLE
Fix and test for unused dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,32 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+  unused:
+    name: Unused dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - ""
+          - "--features sentry"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      
+      - name: Install udeps
+        run: cargo install cargo-udeps --locked
+
+      - name: cargo udeps
+        run: cargo udeps --all-targets ${{ matrix.features }}
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,28 +268,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -299,32 +283,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -344,11 +306,8 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -693,7 +652,6 @@ name = "ntp-daemon"
 version = "0.1.0"
 dependencies = [
  "clap",
- "futures",
  "ntp-os-clock",
  "ntp-proto",
  "ntp-udp",
@@ -1313,7 +1271,6 @@ name = "test-binaries"
 version = "0.1.0"
 dependencies = [
  "clap",
- "futures",
  "ntp-daemon",
  "ntp-os-clock",
  "ntp-proto",

--- a/ntp-daemon/Cargo.toml
+++ b/ntp-daemon/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 tokio = { version = "1.19.2", features = ["full"] }
-futures = "0.3.21"
 ntp-proto = { path = "../ntp-proto" }
 ntp-os-clock = { path = "../ntp-os-clock" }
 ntp-udp = { path = "../ntp-udp" }

--- a/test-binaries/Cargo.toml
+++ b/test-binaries/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 tokio = { version = "1.19.2", features = ["full"] }
-futures = "0.3.21"
 ntp-proto = { path = "../ntp-proto" }
 ntp-udp = { path = "../ntp-udp" }
 ntp-daemon = { path = "../ntp-daemon" }


### PR DESCRIPTION
Turns out we had futures as an unused dependency. This should remove that and warn us if we create another unused dependency.