### PR TITLE
readme: the foundation is separate from the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ This crate contains extremely limited NTP servers for testing purposes
 
 We try to keep NTPD-rs working on at least the latest stable, beta and nightly rust compiler. Beyond this, we keep track of the current minimum rust version needed to compile our code for purposes of documentation. However, right now we do not have a policy guaranteeing a minimum amount of time we will support a stable rust release beyond the 6 weeks during which it is the latest stable version.
 
-Please note that the rust foundation only supports the latest stable rust release. As this is the only release that will receive any security updates, we STRONGLY recommend using the latest stable rust version for compiling NTPD-rs for daily use.
+Please note that the Rust project only supports the latest stable rust release. As this is the only release that will receive any security updates, we STRONGLY recommend using the latest stable rust version for compiling NTPD-rs for daily use.


### PR DESCRIPTION
Note also that the project does all the decisions regarding Rust itself, including what toolchain versions are supported.