### PR TITLE
udp backport timestamping improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.60.0
+          - 1.62.0
         os: [ubuntu-latest]
         features:
           - ""


### PR DESCRIPTION
- bump rust version to 1.62.0 (for extern const fn)
- remove allocation by using const extern fn
- refactor udp recv
