### PR TITLE
Note why MD5 is used in ntp-proto Cargo.toml

### DIFF
--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -11,6 +11,7 @@ fuzz = []
 ext-test = []
 
 [dependencies]
+# Note: md5 is needed to calculate ReferenceIDs for IPv6 addresses per RFC5905
 md-5 = "0.10.5"
 rand = "0.8.5"
 tracing = "0.1.36"


### PR DESCRIPTION
Added this note since I was confused why we used MD5 even though it is known insecure.