### PR TITLE
handle sender of the reset channel being dropped

### DIFF
--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -257,7 +257,7 @@ where
                         }
                     }
                 },
-                result = self.channels.reset.changed() => {
+                result = (self.channels.reset.changed()), if self.channels.reset.has_changed().is_ok() => {
                     if let Ok(()) = result {
                         // reset the measurement state (as if this association was just created).
                         // crucially, this sets `self.next_expected_origin = None`, meaning that


### PR DESCRIPTION
fun fact: when the sender of a `Watch` is dropped, the `recv` call immediately succeeds. That means that in tests, where we usually drop this sender with a `_ = ..` pattern match, the `run` function would just loop endlessly to the `reset` branch. 