### PR TITLE
handle sender of the reset channel being dropped

### DIFF
--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -257,7 +257,7 @@ where
                         }
                     }
                 },
-                result = self.channels.reset.changed() => {
+                result = (self.channels.reset.changed()), if self.channels.reset.has_changed().is_ok() => {
                     if let Ok(()) = result {
                         // reset the measurement state (as if this association was just created).
                         // crucially, this sets `self.next_expected_origin = None`, meaning that


### PR DESCRIPTION
if the sender has already been dropped, `changed` will immediately resolve, effectively always taking that branch. We often drop the sender in our tests. The documentation is not very clear about it

> If the newest value has already been marked seen, then the method sleeps until a new message is sent by the [Sender](https://docs.rs/tokio/latest/tokio/sync/watch/struct.Sender.html) connected to this Receiver, or until the [Sender](https://docs.rs/tokio/latest/tokio/sync/watch/struct.Sender.html) is dropped.

but this is effectively the behavior that we (@rnijveld  and I) observed