### PR TITLE
add second encryption algorithm

### DIFF
--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -133,7 +133,7 @@ impl Cipher for AesSivCmac512 {
         associated_data: &[u8],
     ) -> std::io::Result<EncryptionResult> {
         let mut siv = Aes256Siv::new(&self.key);
-        let nonce: [u8; 32] = rand::thread_rng().gen();
+        let nonce: [u8; 16] = rand::thread_rng().gen();
         let ciphertext = match siv.encrypt([associated_data, &nonce], plaintext) {
             Ok(v) => v,
             Err(e) => {

--- a/ntp-proto/src/packet/mod.rs
+++ b/ntp-proto/src/packet/mod.rs
@@ -15,7 +15,9 @@ mod error;
 mod extensionfields;
 mod mac;
 
-pub use crypto::{AesSivCmac256, Cipher, CipherProvider, EncryptionResult, NoCipher};
+pub use crypto::{
+    AesSivCmac256, AesSivCmac512, Cipher, CipherProvider, EncryptionResult, NoCipher,
+};
 pub use error::PacketParsingError;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/test-binaries/src/bin/nts-ke.rs
+++ b/test-binaries/src/bin/nts-ke.rs
@@ -215,7 +215,8 @@ pub(crate) async fn perform_key_exchange(
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let domain = "time.cloudflare.com";
+    // let domain = "time.cloudflare.com";
+    let domain = "nts.time.nl"; // supports AesSivCmac512
     let port = 4460;
 
     let mut key_exchange = perform_key_exchange(domain.to_string(), port)


### PR DESCRIPTION
adds a second encryption algorithm, and the required infrastructure. I picked `AesSivCmac512` which seemed the most useful and straightforward to me.

I've verified using the `nts-ke` example that `AesSivCmac512` works (with `nts.time.nl`, cloudflare does not seem to support it)