### PR TITLE
Return a parsed packet when decryption failed.

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0224938f92e7aef515fac2ff2d18bd1115c1394ddf4a092e0c87e8be9499ee5"
+checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf460bbff5f571bfc762da5102729f59f338be7db17a21fade44c5c4f5005350"
+checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -291,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -451,6 +467,15 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -635,21 +660,21 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
+checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
  "itoa",
  "parking_lot",
- "prometheus-client-derive-text-encode",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
+name = "prometheus-client-derive-encode"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -866,12 +891,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -1009,11 +1043,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/ntp-proto/src/packet/error.rs
+++ b/ntp-proto/src/packet/error.rs
@@ -12,27 +12,27 @@ pub enum ParsingError<T> {
 }
 
 impl<T> ParsingError<T> {
-    pub(super) fn coerce<U>(self) -> Option<ParsingError<U>> {
+    pub(super) fn get_decrypt_error<U>(self) -> Result<T, ParsingError<U>> {
         match self {
-            ParsingError::InvalidVersion(v) => Some(ParsingError::InvalidVersion(v)),
-            ParsingError::IncorrectLength => Some(ParsingError::IncorrectLength),
+            ParsingError::InvalidVersion(v) => Err(ParsingError::InvalidVersion(v)),
+            ParsingError::IncorrectLength => Err(ParsingError::IncorrectLength),
             ParsingError::MalformedNtsExtensionFields => {
-                Some(ParsingError::MalformedNtsExtensionFields)
+                Err(ParsingError::MalformedNtsExtensionFields)
             }
-            ParsingError::MalformedNonce => Some(ParsingError::MalformedNonce),
-            ParsingError::DecryptError(_) => None,
+            ParsingError::MalformedNonce => Err(ParsingError::MalformedNonce),
+            ParsingError::DecryptError(decrypt_error) => Ok(decrypt_error),
         }
     }
 }
 
 impl ParsingError<std::convert::Infallible> {
-    pub(super) fn force<U>(self) -> ParsingError<U> {
+    pub(super) fn generalize<U>(self) -> ParsingError<U> {
         match self {
             ParsingError::InvalidVersion(v) => ParsingError::InvalidVersion(v),
             ParsingError::IncorrectLength => ParsingError::IncorrectLength,
             ParsingError::MalformedNtsExtensionFields => ParsingError::MalformedNtsExtensionFields,
             ParsingError::MalformedNonce => ParsingError::MalformedNonce,
-            ParsingError::DecryptError(_) => unreachable!(),
+            ParsingError::DecryptError(decrypt_error) => match decrypt_error {},
         }
     }
 }

--- a/ntp-proto/src/packet/error.rs
+++ b/ntp-proto/src/packet/error.rs
@@ -1,24 +1,54 @@
 use std::fmt::Display;
 
+use crate::NtpPacket;
+
 #[derive(Debug)]
-pub enum PacketParsingError {
+pub enum ParsingError<T> {
     InvalidVersion(u8),
     IncorrectLength,
     MalformedNtsExtensionFields,
     MalformedNonce,
-    DecryptError,
+    DecryptError(T),
 }
 
-impl Display for PacketParsingError {
+impl<T> ParsingError<T> {
+    pub(super) fn coerce<U>(self) -> Option<ParsingError<U>> {
+        match self {
+            ParsingError::InvalidVersion(v) => Some(ParsingError::InvalidVersion(v)),
+            ParsingError::IncorrectLength => Some(ParsingError::IncorrectLength),
+            ParsingError::MalformedNtsExtensionFields => {
+                Some(ParsingError::MalformedNtsExtensionFields)
+            }
+            ParsingError::MalformedNonce => Some(ParsingError::MalformedNonce),
+            ParsingError::DecryptError(_) => None,
+        }
+    }
+}
+
+impl ParsingError<std::convert::Infallible> {
+    pub(super) fn force<U>(self) -> ParsingError<U> {
+        match self {
+            ParsingError::InvalidVersion(v) => ParsingError::InvalidVersion(v),
+            ParsingError::IncorrectLength => ParsingError::IncorrectLength,
+            ParsingError::MalformedNtsExtensionFields => ParsingError::MalformedNtsExtensionFields,
+            ParsingError::MalformedNonce => ParsingError::MalformedNonce,
+            ParsingError::DecryptError(_) => unreachable!(),
+        }
+    }
+}
+
+pub type PacketParsingError<'a> = ParsingError<NtpPacket<'a>>;
+
+impl<T> Display for ParsingError<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InvalidVersion(version) => f.write_fmt(format_args!("Invalid version {version}")),
             Self::IncorrectLength => f.write_str("Incorrect packet length"),
             Self::MalformedNtsExtensionFields => f.write_str("Malformed nts extension fields"),
             Self::MalformedNonce => f.write_str("Malformed nonce (likely invalid length)"),
-            Self::DecryptError => f.write_str("Failed to decrypt NTS extension fields"),
+            Self::DecryptError(_) => f.write_str("Failed to decrypt NTS extension fields"),
         }
     }
 }
 
-impl std::error::Error for PacketParsingError {}
+impl<T: std::fmt::Debug> std::error::Error for ParsingError<T> {}

--- a/ntp-proto/src/packet/mac.rs
+++ b/ntp-proto/src/packet/mac.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::PacketParsingError;
+use super::error::ParsingError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct Mac<'a> {
@@ -23,9 +23,11 @@ impl<'a> Mac<'a> {
         w.write_all(&self.mac)
     }
 
-    pub(super) fn deserialize(data: &'a [u8]) -> Result<Mac<'a>, PacketParsingError> {
+    pub(super) fn deserialize(
+        data: &'a [u8],
+    ) -> Result<Mac<'a>, ParsingError<std::convert::Infallible>> {
         if data.len() < 4 || data.len() >= Self::MAXIMUM_SIZE {
-            return Err(PacketParsingError::IncorrectLength);
+            return Err(ParsingError::IncorrectLength);
         }
 
         Ok(Mac {

--- a/ntp-proto/src/packet/mod.rs
+++ b/ntp-proto/src/packet/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{NtpClock, NtpDuration, NtpTimestamp, PollInterval, ReferenceId, SystemSnapshot};
 
 use self::{
+    error::ParsingError,
     extensionfields::{ExtensionField, ExtensionFieldData},
     mac::Mac,
 };
@@ -161,9 +162,9 @@ impl NtpHeaderV3V4 {
         }
     }
 
-    fn deserialize(data: &[u8]) -> Result<(Self, usize), PacketParsingError> {
+    fn deserialize(data: &[u8]) -> Result<(Self, usize), ParsingError<std::convert::Infallible>> {
         if data.len() < Self::LENGTH {
-            return Err(PacketParsingError::IncorrectLength);
+            return Err(ParsingError::IncorrectLength);
         }
 
         Ok((
@@ -272,10 +273,11 @@ impl<'a> NtpPacket<'a> {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn deserialize(
         data: &'a [u8],
         cipher: &impl CipherProvider,
-    ) -> Result<Self, PacketParsingError> {
+    ) -> Result<Self, PacketParsingError<'a>> {
         if data.is_empty() {
             return Err(PacketParsingError::IncorrectLength);
         }
@@ -284,9 +286,10 @@ impl<'a> NtpPacket<'a> {
 
         match version {
             3 => {
-                let (header, header_size) = NtpHeaderV3V4::deserialize(data)?;
+                let (header, header_size) =
+                    NtpHeaderV3V4::deserialize(data).map_err(|e| e.force())?;
                 let mac = if header_size != data.len() {
-                    Some(Mac::deserialize(&data[header_size..])?)
+                    Some(Mac::deserialize(&data[header_size..]).map_err(|e| e.force())?)
                 } else {
                     None
                 };
@@ -297,21 +300,39 @@ impl<'a> NtpPacket<'a> {
                 })
             }
             4 => {
-                let (header, header_size) = NtpHeaderV3V4::deserialize(data)?;
+                let mut has_invalid_nts = false;
+
+                let (header, header_size) =
+                    NtpHeaderV3V4::deserialize(data).map_err(|e| e.force())?;
                 let (efdata, header_plus_fields_len) =
-                    ExtensionFieldData::deserialize(data, header_size, cipher)?;
+                    match ExtensionFieldData::deserialize(data, header_size, cipher) {
+                        Ok(v) => v,
+                        Err(ParsingError::DecryptError(v)) => {
+                            has_invalid_nts = true;
+                            v
+                        }
+                        Err(e) => return Err(e.coerce().unwrap()), // Won't panic as DecryptError is caught above
+                    };
 
                 let mac = if header_plus_fields_len != data.len() {
-                    Some(Mac::deserialize(&data[header_plus_fields_len..])?)
+                    Some(Mac::deserialize(&data[header_plus_fields_len..]).map_err(|e| e.force())?)
                 } else {
                     None
                 };
 
-                Ok(NtpPacket {
-                    header: NtpHeader::V4(header),
-                    efdata,
-                    mac,
-                })
+                if has_invalid_nts {
+                    Err(ParsingError::DecryptError(NtpPacket {
+                        header: NtpHeader::V4(header),
+                        efdata,
+                        mac,
+                    }))
+                } else {
+                    Ok(NtpPacket {
+                        header: NtpHeader::V4(header),
+                        efdata,
+                        mac,
+                    })
+                }
             }
             _ => Err(PacketParsingError::InvalidVersion(version)),
         }


### PR DESCRIPTION
This is needed for a server to be able to send nts-nak packets, since it then does need information contained unencrypted in the clients packet.