### PR TITLE
Put bounds on maximum frequency steering to avoid going into non-supported regions.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -199,6 +199,7 @@ A second set of options control more internal details of how the algorithm estim
 | poll-low-weight | 0.4 | Ammount which a measurement contributes to the state, below which we start increasing the poll interval. (weight, 0-1) |
 | poll-high-weight | 0.6 | Ammount which a measurement contributes to the state, above which we start decreasing the poll interval. (weight, 0-1) |
 | poll-hysteresis | 16 | Ammount of hysteresis in changeing the poll interval (count, 1+) |
+| max-frequency-steer | 495e-6 | Maximum steering input to system clock. (s/s) |
 
 #### Example configuration file:
 

--- a/ntp-proto/src/algorithm/kalman/config.rs
+++ b/ntp-proto/src/algorithm/kalman/config.rs
@@ -93,6 +93,10 @@ pub struct AlgorithmConfig {
     #[serde(default = "default_slew_min_duration")]
     pub slew_min_duration: f64,
 
+    /// Absolute maximum frequency correction (s/s)
+    #[serde(default = "default_max_frequency_steer")]
+    pub max_frequency_steer: f64,
+
     /// Ignore a servers advertised dispersion when synchronizing.
     /// Can improve synchronization quality with servers reporting
     /// overly conservative root dispersion.
@@ -129,6 +133,8 @@ impl Default for AlgorithmConfig {
             jump_threshold: default_jump_threshold(),
             slew_max_frequency_offset: default_slew_max_frequency_offset(),
             slew_min_duration: default_slew_min_duration(),
+
+            max_frequency_steer: default_max_frequency_steer(),
 
             ignore_server_dispersion: false,
         }
@@ -213,6 +219,10 @@ fn default_jump_threshold() -> f64 {
 
 fn default_slew_max_frequency_offset() -> f64 {
     200e-6
+}
+
+fn default_max_frequency_steer() -> f64 {
+    495e-6
 }
 
 fn default_slew_min_duration() -> f64 {


### PR DESCRIPTION
This is needed on platforms with very instable clocks, as otherwise we might accidentally oversteer, which has some interesting effects on linux (results in no steering, which confuses the heck out of the rest of the algorithm, or any human watching for that matter).