### PR TITLE
Box NTS data to prevent moving it around and to prevent unbalanced enum in spawning

### DIFF
--- a/ntp-daemon/src/config/mod.rs
+++ b/ntp-daemon/src/config/mod.rs
@@ -21,7 +21,7 @@ use tokio::{fs::read_to_string, io};
 use tracing::{info, warn};
 use tracing_subscriber::filter::EnvFilter;
 
-use crate::system::PeerIndex;
+use crate::spawn::PeerId;
 
 use self::format::LogFormat;
 
@@ -107,9 +107,9 @@ pub struct CombinedSystemConfig {
     #[serde(flatten)]
     pub system: SystemConfig,
     #[serde(flatten)]
-    pub algorithm: <DefaultTimeSyncController<UnixNtpClock, PeerIndex> as TimeSyncController<
+    pub algorithm: <DefaultTimeSyncController<UnixNtpClock, PeerId> as TimeSyncController<
         UnixNtpClock,
-        PeerIndex,
+        PeerId,
     >>::AlgorithmConfig,
 }
 

--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -270,7 +270,7 @@ where
         clock: C,
         network_wait_period: std::time::Duration,
         mut channels: PeerChannels,
-        nts: Option<PeerNtsData>,
+        nts: Option<Box<PeerNtsData>>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(
             (async move {

--- a/ntp-daemon/src/spawn/dummy.rs
+++ b/ntp-daemon/src/spawn/dummy.rs
@@ -33,7 +33,7 @@ impl DummySpawner {
     pub fn simple(addr: Vec<SocketAddr>, keep_active: usize) -> DummySpawner {
         let to_spawn = addr
             .into_iter()
-            .map(PeerCreateParameters::from_addr)
+            .map(PeerCreateParameters::from_new_addr)
             .collect();
         Self::new(to_spawn, keep_active)
     }

--- a/ntp-daemon/src/spawn/mod.rs
+++ b/ntp-daemon/src/spawn/mod.rs
@@ -55,7 +55,6 @@ pub struct SpawnEvent {
 }
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum SystemEvent {
     PeerRemoved(PeerRemovedEvent),
     PeerRegistered(PeerCreateParameters),
@@ -65,20 +64,6 @@ pub enum SystemEvent {
 impl SystemEvent {
     pub fn peer_removed(id: PeerId, reason: PeerRemovalReason) -> SystemEvent {
         SystemEvent::PeerRemoved(PeerRemovedEvent { id, reason })
-    }
-
-    pub fn peer_registered(
-        id: PeerId,
-        addr: SocketAddr,
-        normalized_addr: NormalizedAddress,
-        nts: Option<PeerNtsData>,
-    ) -> SystemEvent {
-        SystemEvent::PeerRegistered(PeerCreateParameters {
-            id,
-            addr,
-            normalized_addr,
-            nts,
-        })
     }
 }
 
@@ -113,7 +98,7 @@ impl SpawnAction {
         id: PeerId,
         addr: SocketAddr,
         normalized_addr: NormalizedAddress,
-        nts: Option<PeerNtsData>,
+        nts: Option<Box<PeerNtsData>>,
     ) -> SpawnAction {
         SpawnAction::Create(PeerCreateParameters {
             id,
@@ -129,7 +114,7 @@ pub struct PeerCreateParameters {
     pub id: PeerId,
     pub addr: SocketAddr,
     pub normalized_addr: NormalizedAddress,
-    pub nts: Option<PeerNtsData>,
+    pub nts: Option<Box<PeerNtsData>>,
 }
 
 #[cfg(test)]

--- a/ntp-proto/src/nts_record.rs
+++ b/ntp-proto/src/nts_record.rs
@@ -623,7 +623,7 @@ impl KeyExchangeResultDecoder {
 pub struct KeyExchangeResult {
     pub remote: String,
     pub port: u16,
-    pub nts: PeerNtsData,
+    pub nts: Box<PeerNtsData>,
 }
 
 pub struct KeyExchangeClient {
@@ -674,11 +674,11 @@ impl KeyExchangeClient {
                                 Err(e) => return ControlFlow::Break(Err(KeyExchangeError::Tls(e))),
                             };
 
-                            let nts = PeerNtsData {
+                            let nts = Box::new(PeerNtsData {
                                 cookies: result.cookies,
                                 c2s: keys.c2s,
                                 s2c: keys.s2c,
-                            };
+                            });
 
                             return ControlFlow::Break(Ok(KeyExchangeResult {
                                 remote: result.remote.unwrap_or(self.server_name),

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -48,7 +48,7 @@ impl std::fmt::Debug for PeerNtsData {
 
 #[derive(Debug)]
 pub struct Peer {
-    nts: Option<PeerNtsData>,
+    nts: Option<Box<PeerNtsData>>,
 
     // Poll interval dictated by unreachability backoff
     backoff_interval: PollInterval,
@@ -298,7 +298,7 @@ impl Peer {
         peer_id: ReferenceId,
         local_clock_time: NtpInstant,
         system_config: SystemConfig,
-        nts: PeerNtsData,
+        nts: Box<PeerNtsData>,
     ) -> Self {
         Self {
             nts: Some(nts),


### PR DESCRIPTION
This is mainly caused by the cookies being stored in place in the NTS data struct.