### PR TITLE
make log output of the standard algorithm less spammy

### DIFF
--- a/ntp-proto/src/algorithm/kalman/peer.rs
+++ b/ntp-proto/src/algorithm/kalman/peer.rs
@@ -335,7 +335,7 @@ impl PeerFilter {
         self.update_desired_poll(config, algo_config, chi, weight, measurement_period);
 
         debug!(
-            "peer offset {}+-{}ms, freq {}+-{}ppm",
+            "peer offset {}±{}ms, freq {}±{}ppm",
             self.state.entry(0) * 1000.,
             (self.uncertainty.entry(0, 0) + sqr(self.last_packet.root_dispersion().to_seconds()))
                 .sqrt()

--- a/ntp-proto/src/algorithm/standard/clock_controller.rs
+++ b/ntp-proto/src/algorithm/standard/clock_controller.rs
@@ -75,7 +75,7 @@ impl<C: NtpClock> ClockController<C> {
     const POLL_ADJUST: i32 = 30;
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     pub fn update(
         &mut self,
         config: &SystemConfig,
@@ -342,6 +342,16 @@ impl<C: NtpClock> ClockController<C> {
             error!(error = %e, "Unable to adjust clock frequency, exiting");
             std::process::exit(exitcode::NOPERM);
         }
+    }
+
+    /// Are we still gathering initial samples?
+    pub fn is_startup(&self) -> bool {
+        matches!(self.state, ClockState::StartupBlank)
+    }
+
+    /// Are we still gathering frequency data?
+    pub fn is_measuring_frequency(&self) -> bool {
+        matches!(self.state, ClockState::MeasureFreq)
     }
 }
 

--- a/ntp-proto/src/algorithm/standard/clock_select.rs
+++ b/ntp-proto/src/algorithm/standard/clock_select.rs
@@ -17,7 +17,7 @@ pub(super) struct FilterAndCombine<PeerID: Hash + Eq + Copy + Debug> {
 }
 
 impl<PeerID: Hash + Eq + Copy + Debug> FilterAndCombine<PeerID> {
-    #[instrument(skip(peers), fields(peers = debug(peers.iter().map(|peer| peer.0).collect::<Vec<_>>())))]
+    #[instrument(level = "debug", skip(peers), fields(peers = debug(peers.iter().map(|peer| peer.0).collect::<Vec<_>>())))]
     pub fn run(
         config: &SystemConfig,
         algo_config: &AlgorithmConfig,
@@ -71,7 +71,10 @@ struct ClockSelect<'a, PeerID: Hash + Eq + Copy + Debug> {
     system_selection_jitter: NtpDuration,
 }
 
-#[instrument(skip(config, algo_config, local_clock_time, system_poll))]
+#[instrument(
+    level = "debug",
+    skip(config, algo_config, local_clock_time, system_poll)
+)]
 fn clock_select<'a, PeerID: Hash + Eq + Copy + Debug>(
     config: &SystemConfig,
     algo_config: &AlgorithmConfig,


### PR DESCRIPTION
fix #569 

does not log all arguments to functions, and is clearer about what state the algorithm is in

```
2023-03-03T09:54:17.607247Z  INFO ntp_daemon::config: using config file path="ntp.toml"
2023-03-03T09:54:17.608600Z  INFO ntp_daemon::tracing: Log filter override from command line arguments is active
2023-03-03T09:54:17.608803Z  INFO ntp_daemon::system: Running spawner id=SpawnerId(1) ty="pool" addr="pool.ntp.org:123 (4)"
2023-03-03T09:54:17.609083Z ERROR ntp_daemon::observer: Abnormal termination of state observer: Could not create observe socket at "/run/ntpd-rs/observe" because its parent directory does not exist
2023-03-03T09:54:17.619601Z  INFO ntp_daemon::system: new peer peer_id=PeerId(1) addr=178.215.228.24:123 spawner=SpawnerId(1)
2023-03-03T09:54:17.619851Z  INFO ntp_daemon::system: new peer peer_id=PeerId(2) addr=162.159.200.1:123 spawner=SpawnerId(1)
2023-03-03T09:54:17.620016Z  INFO ntp_daemon::system: new peer peer_id=PeerId(3) addr=129.250.35.250:123 spawner=SpawnerId(1)
2023-03-03T09:54:17.620155Z  INFO ntp_daemon::system: new peer peer_id=PeerId(4) addr=95.211.123.72:123 spawner=SpawnerId(1)
2023-03-03T09:54:17.621705Z  WARN ntp_proto::peer: Peer rejected due to invalid stratum stratum=16
2023-03-03T09:54:17.621760Z  WARN ntp_proto::peer: Peer rejected due to invalid stratum stratum=16
2023-03-03T09:54:17.621797Z  WARN ntp_proto::peer: Peer rejected due to invalid stratum stratum=16
2023-03-03T09:54:17.621832Z  WARN ntp_proto::peer: Peer rejected due to invalid stratum stratum=16
2023-03-03T09:54:17.631326Z  WARN ntp_proto::algorithm::standard::clock_select: No clique of peers that agree on the current time.
2023-03-03T09:54:17.631367Z  INFO ntp_proto::algorithm::standard: ntpd-rs is still starting up (collecting initial samples)
2023-03-03T09:54:17.631875Z  WARN ntp_proto::algorithm::standard::clock_select: No clique of peers that agree on the current time.
2023-03-03T09:54:17.631904Z  INFO ntp_proto::algorithm::standard: ntpd-rs is still starting up (collecting initial samples)
2023-03-03T09:54:17.635258Z  WARN ntp_proto::algorithm::standard::clock_select: No clique of peers that agree on the current time.
2023-03-03T09:54:17.635294Z  INFO ntp_proto::algorithm::standard: ntpd-rs is still starting up (collecting initial samples)
2023-03-03T09:54:17.638288Z  WARN ntp_proto::algorithm::standard::clock_select: No clique of peers that agree on the current time.
```