### PR TITLE
add the `force-unwind-tables` rust flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "force-unwind-tables"]


### PR DESCRIPTION
Gives much better backtraces on panics